### PR TITLE
Support for AIX and targetted SSH testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 train-*.gem
+r-train-*.gem
 Gemfile.lock
 .kitchen/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 train-*.gem
 Gemfile.lock
+.kitchen/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ train = Train.create('local')
 ```ruby
 require 'train'
 train = Train.create('ssh',
-  host: '1.2.3.4', port: 22, user: 'root', keys: '/vagrant')
+  host: '1.2.3.4', port: 22, user: 'root', key_files: '/vagrant')
 ```
 
 **WinRM**

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ train = Train.create('local')
 ```ruby
 require 'train'
 train = Train.create('ssh',
-  host: '1.2.3.4', port: 22, user: 'root', key_files: '/vagrant')
+  host: '1.2.3.4', port: 22, user: 'root', keys: '/vagrant')
 ```
 
 **WinRM**

--- a/Rakefile
+++ b/Rakefile
@@ -45,13 +45,16 @@ namespace :test do
   #   rake "test:ssh[user@server, true]"
   # to use a different key_file but no debug logs:
   #   rake "test:ssh[user@server, false, /home/foobarbam/.ssh/id_rsa2]"
+  # run with a specific test
+  #   test=path_block_device_test.rb rake "test:ssh[user@server]"
   task :ssh, [:target, :debug, :key_files] do |t, args|
     path = File.join(File.dirname(__FILE__), 'test', 'integration')
     key_files = args[:key_files] || File.join(ENV['HOME'], '.ssh', 'id_rsa')
 
     sh_cmd =  "cd #{path} && target=#{args[:target]} key_files=#{key_files}"
     sh_cmd += " debug=#{args[:debug]}" if args[:debug]
-    sh_cmd += ' ruby -I ../../lib test_ssh.rb tests/*'
+    sh_cmd += ' ruby -I ../../lib test_ssh.rb tests/'
+    sh_cmd += ENV['test'] || '*'
     sh(
       'sh', '-c',
       sh_cmd

--- a/Rakefile
+++ b/Rakefile
@@ -48,8 +48,7 @@ namespace :test do
   #   key_file=/home/foobarbam/.ssh/id_rsa2 rake "test:ssh[user@server]"
   # Run with a specific test:
   #   test=path_block_device_test.rb rake "test:ssh[user@server]"
-  task :ssh, [:target, :debug, :key_files] do |t, args|
-  #task :ssh, [:target] do |t, args|
+  task :ssh, [:target] do |t, args|
     path = File.join(File.dirname(__FILE__), 'test', 'integration')
     key_files = ENV['key_files'] || File.join(ENV['HOME'], '.ssh', 'id_rsa')
 

--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,27 @@ namespace :test do
     path = File.join(File.dirname(__FILE__), 'test', 'integration')
     sh('sh', '-c', "cd #{path} && kitchen test -c #{concurrency}")
   end
+
+  # rake "test:ssh[user@server]"
+  # sh -c cd /home/foobarbam/src/gems/train/test/integration \
+  #   && target=user@server key_files=/home/foobarbam/.ssh/id_rsa \
+  #   ruby -I ../../lib test_ssh.rb tests/*
+  # to turn debug logging back on:
+  #   rake "test:ssh[user@server, true]"
+  # to use a different key_file but no debug logs:
+  #   rake "test:ssh[user@server, false, /home/foobarbam/.ssh/id_rsa2]"
+  task :ssh, [:target, :debug, :key_files] do |t, args|
+    path = File.join(File.dirname(__FILE__), 'test', 'integration')
+    key_files = args[:key_files] || File.join(ENV['HOME'], '.ssh', 'id_rsa')
+
+    sh_cmd =  "cd #{path} && target=#{args[:target]} key_files=#{key_files}"
+    sh_cmd += " debug=#{args[:debug]}" if args[:debug]
+    sh_cmd += ' ruby -I ../../lib test_ssh.rb tests/*'
+    sh(
+      'sh', '-c',
+      sh_cmd
+    )
+  end
 end
 
 # Print the current version of this gem or update it.

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ namespace :test do
   # Turn debug logging back on:
   #   debug=1 rake "test:ssh[user@server]"
   # Use a different ssh key:
-  #   key_file=/home/foobarbam/.ssh/id_rsa2 rake "test:ssh[user@server]"
+  #   key_files=/home/foobarbam/.ssh/id_rsa2 rake "test:ssh[user@server]"
   # Run with a specific test:
   #   test=path_block_device_test.rb rake "test:ssh[user@server]"
   task :ssh, [:target] do |t, args|

--- a/Rakefile
+++ b/Rakefile
@@ -37,28 +37,29 @@ namespace :test do
     sh('sh', '-c', "cd #{path} && kitchen test -c #{concurrency}")
   end
 
-  # rake "test:ssh[user@server]"
-  # sh -c cd /home/foobarbam/src/gems/train/test/integration \
-  #   && target=user@server key_files=/home/foobarbam/.ssh/id_rsa \
-  #   ruby -I ../../lib test_ssh.rb tests/*
-  # to turn debug logging back on:
-  #   rake "test:ssh[user@server, true]"
-  # to use a different key_file but no debug logs:
-  #   rake "test:ssh[user@server, false, /home/foobarbam/.ssh/id_rsa2]"
-  # run with a specific test
+  # Target required:
+  #   rake "test:ssh[user@server]"
+  #   sh -c cd /home/foobarbam/src/gems/train/test/integration \
+  #     && target=user@serverruby -I ../../lib test_ssh.rb tests/*
+  #   ...
+  # Turn debug logging back on:
+  #   debug=1 rake "test:ssh[user@server]"
+  # Use a different ssh key:
+  #   key_file=/home/foobarbam/.ssh/id_rsa2 rake "test:ssh[user@server]"
+  # Run with a specific test:
   #   test=path_block_device_test.rb rake "test:ssh[user@server]"
   task :ssh, [:target, :debug, :key_files] do |t, args|
+  #task :ssh, [:target] do |t, args|
     path = File.join(File.dirname(__FILE__), 'test', 'integration')
-    key_files = args[:key_files] || File.join(ENV['HOME'], '.ssh', 'id_rsa')
+    key_files = ENV['key_files'] || File.join(ENV['HOME'], '.ssh', 'id_rsa')
 
-    sh_cmd =  "cd #{path} && target=#{args[:target]} key_files=#{key_files}"
-    sh_cmd += " debug=#{args[:debug]}" if args[:debug]
+    sh_cmd    =  "cd #{path} && target=#{args[:target]} key_files=#{key_files}"
+
+    sh_cmd += " debug=#{ENV['debug']}" if ENV['debug']
     sh_cmd += ' ruby -I ../../lib test_ssh.rb tests/'
     sh_cmd += ENV['test'] || '*'
-    sh(
-      'sh', '-c',
-      sh_cmd
-    )
+
+    sh('sh', '-c', sh_cmd)
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ namespace :test do
   # Target required:
   #   rake "test:ssh[user@server]"
   #   sh -c cd /home/foobarbam/src/gems/train/test/integration \
-  #     && target=user@serverruby -I ../../lib test_ssh.rb tests/*
+  #     && target=user@server ruby -I ../../lib test_ssh.rb tests/*
   #   ...
   # Turn debug logging back on:
   #   debug=1 rake "test:ssh[user@server]"

--- a/lib/train/extras.rb
+++ b/lib/train/extras.rb
@@ -6,6 +6,7 @@ module Train::Extras
   autoload :CommandWrapper, 'train/extras/command_wrapper'
   autoload :FileCommon,     'train/extras/file_common'
   autoload :LinuxFile,      'train/extras/linux_file'
+  autoload :AixFile,        'train/extras/aix_file'
   autoload :WindowsFile,    'train/extras/windows_file'
   autoload :OSCommon,       'train/extras/os_common'
   autoload :Stat,           'train/extras/stat'

--- a/lib/train/extras/aix_file.rb
+++ b/lib/train/extras/aix_file.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 # author: Dominik Richter
 # author: Christoph Hartmann
+# author: Jeremy Chalfant
 
 require 'shellwords'
 require 'train/extras/stat'
@@ -14,17 +15,10 @@ module Train::Extras
 
     def content
       return @content if defined?(@content)
-      @content = @backend.run_command(
-        "cat #{@spath} || echo -n").stdout
+      @content = @backend.run_command("cat #{@spath}").stdout || ''
       return @content unless @content.empty?
       @content = nil if directory? or size.nil? or size > 0
       @content
-    end
-
-    def link_target
-      return @link_target if defined? @link_target
-      return @link_target = nil if link_path.nil?
-      @link_target = @backend.file(link_path)
     end
 
     def link_path
@@ -34,21 +28,6 @@ module Train::Extras
           "perl -e '$ln = readlink(shift) or exit 2; print $ln' #{@spath}"
         ).stdout
       )
-    end
-
-    def mounted?
-      @mounted ||= (
-        !@backend.run_command("mount | grep -- ' on #{@spath}'")
-                 .stdout.empty?
-      )
-    end
-
-    def product_version
-      nil
-    end
-
-    def file_version
-      nil
     end
   end
 end

--- a/lib/train/extras/aix_file.rb
+++ b/lib/train/extras/aix_file.rb
@@ -19,8 +19,6 @@ module Train::Extras
                  else
                    @backend.run_command("cat #{@spath}").stdout || ''
                  end
-
-      @content
     end
 
     def link_path

--- a/lib/train/extras/aix_file.rb
+++ b/lib/train/extras/aix_file.rb
@@ -28,5 +28,11 @@ module Train::Extras
         ).stdout
       )
     end
+
+    def mounted?
+      @mounted ||= (
+        !@backend.run_command("lsfs -c #{@spath}").stdout.empty?
+      )
+    end
   end
 end

--- a/lib/train/extras/aix_file.rb
+++ b/lib/train/extras/aix_file.rb
@@ -1,0 +1,54 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+
+require 'shellwords'
+require 'train/extras/stat'
+
+module Train::Extras
+  class AixFile < LinuxFile
+
+    def initialize(backend, path)
+      super(backend, path)
+    end
+
+    def content
+      return @content if defined?(@content)
+      @content = @backend.run_command(
+        "cat #{@spath} || echo -n").stdout
+      return @content unless @content.empty?
+      @content = nil if directory? or size.nil? or size > 0
+      @content
+    end
+
+    def link_target
+      return @link_target if defined? @link_target
+      return @link_target = nil if link_path.nil?
+      @link_target = @backend.file(link_path)
+    end
+
+    def link_path
+      return nil unless symlink?
+      @link_path ||= (
+        @backend.run_command(
+          "perl -e '$ln = readlink(shift) or exit 2; print $ln' #{@spath}"
+        ).stdout
+      )
+    end
+
+    def mounted?
+      @mounted ||= (
+        !@backend.run_command("mount | grep -- ' on #{@spath}'")
+                 .stdout.empty?
+      )
+    end
+
+    def product_version
+      nil
+    end
+
+    def file_version
+      nil
+    end
+  end
+end

--- a/lib/train/extras/aix_file.rb
+++ b/lib/train/extras/aix_file.rb
@@ -1,7 +1,4 @@
 # encoding: utf-8
-# author: Dominik Richter
-# author: Christoph Hartmann
-# author: Jeremy Chalfant
 
 require 'shellwords'
 require 'train/extras/stat'
@@ -14,18 +11,22 @@ module Train::Extras
 
     def content
       return @content if defined?(@content)
-      @content = @backend.run_command("cat #{@spath}").stdout || ''
-      return @content unless @content.empty?
-      @content = nil if directory? or size.nil? or size > 0
+      @content = case
+                 when !exist?, directory?
+                   nil
+                 when size.nil?, size == 0
+                   ''
+                 else
+                   @backend.run_command("cat #{@spath}").stdout || ''
+                 end
+
       @content
     end
 
     def link_path
       return nil unless symlink?
       @link_path ||= (
-        @backend.run_command(
-          "perl -e '$ln = readlink(shift) or exit 2; print $ln' #{@spath}",
-        ).stdout
+        @backend.run_command("perl -e 'print readlink shift' #{@spath}").stdout.chomp
       )
     end
 

--- a/lib/train/extras/aix_file.rb
+++ b/lib/train/extras/aix_file.rb
@@ -8,7 +8,6 @@ require 'train/extras/stat'
 
 module Train::Extras
   class AixFile < LinuxFile
-
     def initialize(backend, path)
       super(backend, path)
     end
@@ -25,7 +24,7 @@ module Train::Extras
       return nil unless symlink?
       @link_path ||= (
         @backend.run_command(
-          "perl -e '$ln = readlink(shift) or exit 2; print $ln' #{@spath}"
+          "perl -e '$ln = readlink(shift) or exit 2; print $ln' #{@spath}",
         ).stdout
       )
     end

--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -53,6 +53,9 @@ module Train::Extras
       'windows' => %w{
         windows
       },
+      'aix' => %w{
+        aix
+      },
     }
 
     OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware} +

--- a/lib/train/extras/stat.rb
+++ b/lib/train/extras/stat.rb
@@ -20,9 +20,6 @@ module Train::Extras
     end
 
     def self.stat(shell_escaped_path, backend)
-      #require 'pp'
-      #pp backend.os
-      #exit
       return aix_stat(shell_escaped_path, backend) if backend.os.aix?
       return bsd_stat(shell_escaped_path, backend) if backend.os.bsd?
       return linux_stat(shell_escaped_path, backend) if backend.os.unix?
@@ -97,7 +94,7 @@ module Train::Extras
       # Perl here b/c it is default on AIX like stat is on Linux
       stat_cmd = <<-EOF
       perl -e '
-      @a = stat(shift) or exit 2;
+      @a = lstat(shift) or exit 2;
       $u = getpwuid($a[4]);
       $g = getgrgid($a[5]);
       printf("0%o\\n%s\\n%s\\n%d\\n%d\\n", $a[2], $u, $g, $a[9], $a[7])

--- a/lib/train/extras/stat.rb
+++ b/lib/train/extras/stat.rb
@@ -92,14 +92,14 @@ module Train::Extras
 
     def self.aix_stat(shell_escaped_path, backend)
       # Perl here b/c it is default on AIX like stat is on Linux
-      stat_cmd = <<-EOF
+      stat_cmd = <<-EOP
       perl -e '
       @a = lstat(shift) or exit 2;
       $u = getpwuid($a[4]);
       $g = getgrgid($a[5]);
       printf("0%o\\n%s\\n%s\\n%d\\n%d\\n", $a[2], $u, $g, $a[9], $a[7])
       ' #{shell_escaped_path}
-      EOF
+      EOP
 
       res = backend.run_command(stat_cmd)
       return {} if res.exit_status != 0

--- a/lib/train/extras/stat.rb
+++ b/lib/train/extras/stat.rb
@@ -91,7 +91,7 @@ module Train::Extras
     end
 
     def self.aix_stat(shell_escaped_path, backend)
-      # Perl here b/c it is default on AIX like stat is on Linux
+      # Perl here b/c it is default on AIX
       stat_cmd = <<-EOP
       perl -e '
       @a = lstat(shift) or exit 2;

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -58,7 +58,13 @@ class Train::Transports::SSH
     end
 
     def file(path)
-      @files[path] ||= LinuxFile.new(self, path)
+      @files[path] ||= \
+        case os[:family]
+        when 'aix'
+          AixFile.new(self, path)
+        else
+          LinuxFile.new(self, path)
+        end
     end
 
     # (see Base::Connection#run_command)

--- a/test/integration/helper.rb
+++ b/test/integration/helper.rb
@@ -20,8 +20,11 @@ module Test
     end
 
     def root_group(os)
-      if os[:family] == 'freebsd'
+      case os[:family]
+      when 'freebsd'
         'wheel'
+      when 'aix'
+        'system'
       else
         'root'
       end

--- a/test/integration/test_ssh.rb
+++ b/test/integration/test_ssh.rb
@@ -14,7 +14,7 @@ backend_conf = {
 
 backend_conf['target'] = 'ssh://' + backend_conf['target']
 backend_conf['logger'].level = \
-  if ENV['debug'] && !ENV['debug'].to_s.match(/^true$/i)
+  if ENV.key?('debug')
     case ENV['debug'].to_s
     when /^false$/i, /^0$/i
       Logger::INFO

--- a/test/integration/test_ssh.rb
+++ b/test/integration/test_ssh.rb
@@ -3,12 +3,27 @@
 
 require_relative 'helper'
 require 'train'
+require 'logger'
 
 backends = {}
 backend_conf = {
-  'target' => 'ssh://vagrant@localhost',
-  'key_files' => '/root/.ssh/id_rsa',
+  'target'    => ENV['target']    || 'vagrant@localhost',
+  'key_files' => ENV['key_files'] || '/root/.ssh/id_rsa',
+  'logger'    => Logger.new(STDOUT),
 }
+
+backend_conf['target'] = 'ssh://' + backend_conf['target']
+backend_conf['logger'].level = \
+  if ENV['debug'] && !ENV['debug'].to_s.match(/^true$/i)
+    case ENV['debug'].to_s
+    when /^false$/i, /^0$/i
+      Logger::INFO
+    else
+      Logger::DEBUG
+    end
+  else
+    Logger::INFO
+  end
 
 backends[:ssh] = proc { |*args|
   conf = Train.target_config(backend_conf)

--- a/test/integration/tests/path_folder_test.rb
+++ b/test/integration/tests/path_folder_test.rb
@@ -18,7 +18,8 @@ describe 'file interface' do
       file.type.must_equal(:directory)
     end
 
-    if get_backend.call.os[:family] == 'freebsd'
+    case get_backend.call.os[:family]
+    when 'freebsd'
       it 'has freebsd folder content behavior' do
         file.content.must_equal("\u0003\u0000")
       end
@@ -30,6 +31,20 @@ describe 'file interface' do
       it 'has an sha256sum' do
         file.sha256sum.must_equal('9b4fb24edd6d1d8830e272398263cdbf026b97392cc35387b991dc0248a628f9')
       end
+
+    when 'aix'
+      it 'has freebsd folder content behavior' do
+        file.content.must_equal("p\a.\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0002..\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000")
+      end
+
+      it 'has an md5sum' do
+        file.md5sum.must_equal('4c8c0c3807e906c23261d19e5f535cd2')
+      end
+
+      it 'has an sha256sum' do
+        file.sha256sum.must_equal('cac0ea0bb8ecc4561009e9480e73313e5b36a27005e685d88227f4d66abbb0ea')
+      end
+
     else
       it 'has no content' do
         file.content.must_equal(nil)

--- a/test/integration/tests/path_folder_test.rb
+++ b/test/integration/tests/path_folder_test.rb
@@ -32,19 +32,6 @@ describe 'file interface' do
         file.sha256sum.must_equal('9b4fb24edd6d1d8830e272398263cdbf026b97392cc35387b991dc0248a628f9')
       end
 
-    when 'aix'
-      it 'has freebsd folder content behavior' do
-        file.content.must_equal("p\a.\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0002..\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000")
-      end
-
-      it 'has an md5sum' do
-        file.md5sum.must_equal('4c8c0c3807e906c23261d19e5f535cd2')
-      end
-
-      it 'has an sha256sum' do
-        file.sha256sum.must_equal('cac0ea0bb8ecc4561009e9480e73313e5b36a27005e685d88227f4d66abbb0ea')
-      end
-
     else
       it 'has no content' do
         file.content.must_equal(nil)


### PR DESCRIPTION
Add support for AIX platform and ability to test via ssh transport.

See Rakefile ssh task commentary for usage.

All tests pass against my AIX system (lint and docker tests also pass)

```
foobarbam@polaris:~/src/gems/train$ rake test:ssh[user@server]
Run options: --seed 55229

# Running:

...................................................................................................................

Finished in 714.254213s, 0.1610 runs/s, 0.1694 assertions/s.

115 runs, 121 assertions, 0 failures, 0 errors, 0 skips

```