### PR TITLE
Support for local transport on Windows

### DIFF
--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -39,3 +39,18 @@ describe 'linux command' do
     lc.run(cmd).must_equal "echo #{bpw} | base64 -d | sudo -S #{cmd}"
   end
 end
+
+describe 'powershell command' do
+  let(:cls) { Train::Extras::PowerShellCommand }
+  let(:cmd) { rand.to_s }
+  let(:backend) {
+    backend = Train::Transports::Mock.new.connection
+    backend.mock_os({ family: 'windows' })
+    backend
+  }
+
+  it 'wraps commands in powershell' do
+    lc = cls.new(backend, {})
+    lc.run(cmd).must_equal "powershell #{cmd}"
+  end
+end

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -6,6 +6,20 @@
 require 'helper'
 require 'train/transports/local'
 
+# overwrite os detection to simplify mock tests, otherwise run_command tries to
+# determine the OS first and fails the tests
+class Train::Transports::Local::Connection
+  class OS < OSCommon
+    def initialize(backend)
+      super(backend, { family: 'train_mock_os' })
+    end
+
+    def detect_family
+      # no op, we do not need to detect the os
+    end
+  end
+end
+
 describe 'local transport' do
   let(:transport) { Train::Transports::Local.new }
   let(:connection) { transport.connection }

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -2,6 +2,20 @@
 require 'helper'
 require 'train/transports/ssh'
 
+# overwrite os detection to simplify mock tests, otherwise run_command tries to
+# determine the OS first and fails the tests
+class Train::Transports::SSH::Connection
+  class OS < OSCommon
+    def initialize(backend)
+      super(backend, { family: 'train_mock_os' })
+    end
+
+    def detect_family
+      # no op, we do not need to detect the os
+    end
+  end
+end
+
 describe 'ssh transport' do
   let(:cls) { Train::Transports::SSH }
   let(:conf) {{


### PR DESCRIPTION
- ensures the windows detection is run via powershell
- prefix all commands with powershell if `local` transport is used
- adds a small script to run os detection with train only