### PR TITLE
0.9.3 is empty on Windows

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -13,7 +13,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/train/'
   spec.license       = 'Apache 2.0'
 
-  spec.files         = `hash git 2>/dev/null && git ls-files -z`.split("\x0").find_all { |x| x !~ /^\.delivery/ }
+  spec.files = %w{
+    train.gemspec README.md Rakefile LICENSE Gemfile CHANGELOG.md .rubocop.yml
+  } + Dir.glob(
+    '{lib,test}/**/*', File::FNM_DOTMATCH
+  ).reject { |f| File.directory?(f) }
+
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
When performing the ChefDK build on a Windows machine we run `gem build`.  Because the Windows machine does not have the `hash` command then it fails to find any files (and the error is redirected to `/dev/null`) and causes the gem to contain nothing.

To fix this, I just copied the files specification from Inspec.

\cc @chris-rock @arlimus 