### PR TITLE
bugfix: pin net-ssh 2.9 in gem file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ bundler_args: --without integration tools
 matrix:
   include:
   - rvm: 1.9.3
-    gemfile: Gemfile
+    gemfile: Gemfile.193
   - rvm: 2.0
     gemfile: Gemfile
   - rvm: 2.2

--- a/Gemfile.193
+++ b/Gemfile.193
@@ -1,0 +1,28 @@
+# encoding: utf-8
+source 'https://rubygems.org'
+gemspec
+
+# pin dependency for Ruby 1.9.3 since bundler is not
+# detecting that net-ssh 3 does not work with 1.9.3
+gem 'net-ssh', '~> 2.9'
+
+group :test do
+  gem 'bundler', '~> 1.5'
+  gem 'minitest', '~> 5.5'
+  gem 'rake', '~> 10'
+  gem 'rubocop', '~> 0.33.0'
+  gem 'simplecov', '~> 0.10'
+  gem 'concurrent-ruby', '~> 0.9'
+end
+
+group :integration do
+  gem 'berkshelf', '~> 4.0'
+  gem 'test-kitchen', '~> 1.4'
+  gem 'kitchen-vagrant'
+end
+
+group :tools do
+  gem 'pry', '~> 0.10'
+  gem 'license_finder'
+  gem 'github_changelog_generator', '~> 1'
+end


### PR DESCRIPTION
Unfortunately bundler seems not to be smart enough to remove a version that does not fit to the ruby version. Therefore we pin net-ssh for builds on ruby 1.9.3