### PR TITLE
use negotiate auth for winrm and not basic_auth

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,6 @@ install:
   - ps: net localgroup administrators $env:winrm_user /add
   - ps: $env:winrm_cert = (New-SelfSignedCertificate -DnsName localhost -CertStoreLocation cert:\localmachine\my).Thumbprint
   - ps: winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"localhost`";CertificateThumbprint=`"$($env:winrm_cert)`"}"
-  - ps: winrm set winrm/config/client/auth '@{Basic="true"}'
-  - ps: winrm set winrm/config/service/auth '@{Basic="true"}'
-  - ps: winrm set winrm/config/service '@{AllowUnencrypted="true"}'
   - ps: $env:PATH="C:\Ruby$env:ruby_version\bin;$env:PATH"
   - ps: Write-Host $env:PATH
   - gem install bundler --quiet --no-ri --no-rdoc

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -100,9 +100,9 @@ module Train::Transports
     def connection_options(opts)
       {
         logger:                   logger,
-        winrm_transport:          :plaintext,
-        disable_sspi:             true,
-        basic_auth_only:          true,
+        winrm_transport:          :negotiate,
+        disable_sspi:             false,
+        basic_auth_only:          false,
         endpoint:                 opts[:endpoint],
         user:                     opts[:user],
         pass:                     opts[:password],

--- a/train.gemspec
+++ b/train.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   # 1.9 support is no longer needed here or for Inspec
   spec.add_dependency 'net-ssh', '>= 2.9', '< 4.0'
   spec.add_dependency 'net-scp', '~> 1.2'
-  spec.add_dependency 'winrm', '~> 1.5'
+  spec.add_dependency 'winrm', '~> 1.6'
   spec.add_dependency 'winrm-fs', '~> 0.3'
   spec.add_dependency 'docker-api', '~> 1.22'
 


### PR DESCRIPTION
winrm 1.6 provides support for NTLM/Negotiate auth so we should use that instead of `:plaintext` as the default transport. See http://www.hurryupandwait.io/blog/sane-authenticationencryption-arrives-to-ruby-based-cross-platform-winrm-remote-execution