### PR TITLE
Properly wrap commands in powershell for local backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ puts conn.file('/proc/version').content
 conn.close
 ```
 
+# Testing
+
+We perform `unit`, `integration` and `windows` tests.
+
+* `unit` tests ensure the intended behaviour of the implementation
+* `integration` tests run against VMs and docker containers
+* `windows` tests that run on appveyor for windows integration tests
+
+## Windows
+
+```
+# run windows tests
+bundle exec rake test:windows
+
+# run single tests
+bundle exec ruby -I .\test\windows\ .\test\windows\local_test.rb
+```
+
+
 # Kudos and Contributors
 
 Train is heavily based on the work of:

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ namespace :test do
 
   task :windows do
     Dir.glob('test/windows/*_test.rb').all? do |file|
-      sh(Gem.ruby, '-w', '-Ilib:test', file)
+      sh(Gem.ruby, '-w', '-I .\test\windows', file)
     end or fail 'Failures'
   end
 

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -99,12 +99,22 @@ module Train::Extras
     def initialize(backend, options)
       @backend = backend
       validate_options(options)
-
-      @prefix = 'powershell '
     end
 
-    def run(command)
-      @prefix + command
+    def run(script)
+
+      # wrap the script to ensure we always run it via powershell
+      # especially in local mode, we cannot be sure that we get a Powershell
+      # we may just get a `cmd`.
+      # TODO: we may want to opt for powershell.exe -command instead of `encodeCommand`
+      cmd = "powershell -encodedCommand #{WinRM::PowershellScript.new(safe_script(script)).encoded}"
+      cmd
+    end
+
+    # reused from https://github.com/WinRb/WinRM/blob/master/lib/winrm/command_executor.rb
+    # suppress the progress stream from leaking to stderr
+    def safe_script(script)
+      "$ProgressPreference='SilentlyContinue';" + script
     end
 
     def to_s

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -102,13 +102,11 @@ module Train::Extras
     end
 
     def run(script)
-
       # wrap the script to ensure we always run it via powershell
       # especially in local mode, we cannot be sure that we get a Powershell
       # we may just get a `cmd`.
       # TODO: we may want to opt for powershell.exe -command instead of `encodeCommand`
-      cmd = "powershell -encodedCommand #{WinRM::PowershellScript.new(safe_script(script)).encoded}"
-      cmd
+      "powershell -encodedCommand #{WinRM::PowershellScript.new(safe_script(script)).encoded}"
     end
 
     # reused from https://github.com/WinRb/WinRM/blob/master/lib/winrm/command_executor.rb

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -35,7 +35,7 @@ module Train::Transports
   # @author Matt Wrock <matt@mattwrock.com>
   # @author Salim Afiune <salim@afiunemaya.com.mx>
   # @author Fletcher Nichol <fnichol@nichol.ca>
-  class WinRM < Train.plugin(1) # rubocop:disable Metrics/ClassLength
+  class WinRM < Train.plugin(1)
     name 'winrm'
 
     autoload :Connection, 'train/transports/winrm_connection'

--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -51,6 +51,7 @@ describe 'powershell command' do
 
   it 'wraps commands in powershell' do
     lc = cls.new(backend, {})
-    lc.run(cmd).must_equal "powershell #{cmd}"
+    tmp =
+    lc.run(cmd).must_equal "powershell -encodedCommand #{WinRM::PowershellScript.new('$ProgressPreference=\'SilentlyContinue\';' + cmd).encoded}"
   end
 end

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -27,6 +27,18 @@ describe 'windows local command' do
     os[:arch].must_equal nil
   end
 
+  it 'run echo test' do
+    cmd = conn.run_command('Write-Output "test"')
+    cmd.stdout.must_equal "test\r\n"
+    cmd.stderr.must_equal ''
+  end
+
+  it 'use powershell piping' do
+    cmd = conn.run_command("New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name A -Value (Write-Output 'PropertyA') -PassThru | Add-Member -MemberType NoteProperty -Name B -Value (Write-Output 'PropertyB') -PassThru | ConvertTo-Json")
+    cmd.stdout.must_equal "{\r\n    \"A\":  \"PropertyA\",\r\n    \"B\":  \"PropertyB\"\r\n}\r\n"
+    cmd.stderr.must_equal ''
+  end
+
   after do
     # close the connection
     conn.close

--- a/test/windows/winrm_test.rb
+++ b/test/windows/winrm_test.rb
@@ -33,6 +33,18 @@ describe 'windows local command' do
     os[:arch].must_equal nil
   end
 
+  it 'run echo test' do
+    cmd = conn.run_command('Write-Output "test"')
+    cmd.stdout.must_equal "test\r\n"
+    cmd.stderr.must_equal ''
+  end
+
+  it 'use powershell piping' do
+    cmd = conn.run_command("New-Object -Type PSObject | Add-Member -MemberType NoteProperty -Name A -Value (Write-Output 'PropertyA') -PassThru | Add-Member -MemberType NoteProperty -Name B -Value (Write-Output 'PropertyB') -PassThru | ConvertTo-Json")
+    cmd.stdout.must_equal "{\r\n    \"A\":  \"PropertyA\",\r\n    \"B\":  \"PropertyB\"\r\n}\r\n"
+    cmd.stderr.must_equal ''
+  end
+
   after do
     # close the connection
     conn.close


### PR DESCRIPTION
- use the same approach as done in https://github.com/WinRb/WinRM/blob/master/lib/winrm/command_executor.rb
- add more testing on windows to see if `winrm` or `local` breaks