### PR TITLE
add `requiretty` workaround measures

### DIFF
--- a/contrib/fixup_requiretty.rb
+++ b/contrib/fixup_requiretty.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+# author: Stephan Renatus
+#
+# chef-apply script to fix sudoers configuration
+#
+# This script can be used to setup a user's sudoers configuration to allow for
+# using non-interactive sessions. It's main use case is fixing the default
+# configuration on RHEL and SEL distributions.
+#
+# The user name has to be provided in the env varibale "TRAIN_SUDO_USER".
+# If any configuration for the user is present (user is in /etc/sudoers or
+# /etc/sudoers.d/user exists), this script will do nothing
+# (unless you set TRAIN_SUDO_VERY_MUCH=yes)
+
+# FIXME
+user = ENV['TRAIN_SUDO_USER'] || 'todo-some-clever-default-maybe-current-user'
+sudoer = "/etc/sudoers.d/#{user}"
+
+log "Warning: a sudoers configuration for user #{user} already exists, "\
+    'doing nothing (override with TRAIN_SUDO_VERY_MUCH=yes)' do
+  only_if "test -f #{sudoer} || grep #{user} /etc/sudoers"
+end
+
+file sudoer do
+  content "#{user} ALL=(root) NOPASSWD:ALL\n"\
+          "Defaults:#{user} !requiretty\n"
+  mode 0600
+  action ENV['TRAIN_SUDO_VERY_MUCH'] == 'yes' ? :create : :create_if_missing
+
+  # Do not add something here if the user is mentioned explicitly in /etc/sudoers
+  not_if "grep #{user} /etc/sudoers"
+end
+
+# /!\ broken files in /etc/sudoers.d/ will break sudo for ALL USERS /!\
+execute "revert: delete the file if it's broken" do
+  command "rm #{sudoer}"
+  not_if "visudo -c -f #{sudoer}" # file is ok
+end

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -50,13 +50,18 @@ module Train::Extras
       return nil if res.exit_status == 0
       rawerr = res.stdout + ' ' + res.stderr
 
-      rawerr = 'Wrong sudo password.' if rawerr.include? 'Sorry, try again'
-      if rawerr.include? 'sudo: no tty present and no askpass program specified'
-        rawerr = 'Sudo requires a password, please configure it.'
-      end
-      if rawerr.include? 'sudo: command not found'
-        rawerr = "Can't find sudo command. Please either install and "\
-                 'configure it on the target or deactivate sudo.'
+      {
+        'Sorry, try again' => 'Wrong sudo password.',
+        'sudo: no tty present and no askpass program specified' =>
+          'Sudo requires a password, please configure it.',
+        'sudo: command not found' =>
+          "Can't find sudo command. Please either install and "\
+            'configure it on the target or deactivate sudo.',
+        'sudo: sorry, you must have a tty to run sudo' =>
+          'Sudo requires a TTY. Please see the README on how to configure '\
+            'sudo to allow for non-interactive usage.',
+      }.each do |sudo, human|
+        rawerr = human if rawerr.include? sudo
       end
 
       rawerr

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -26,7 +26,7 @@ execute 'test ssh connection' do
 end
 
 # prepare a few users
-%w{ nopasswd passwd nosudo }.each do |name|
+%w{ nopasswd passwd nosudo reqtty }.each do |name|
   user name do
     password '$1$7MCNTXPI$r./jqCEoVlLlByYKSL3sZ.'
     manage_home true
@@ -37,12 +37,20 @@ end
   sudo name do
     user '%'+name
     nopasswd true
+    defaults ['!requiretty']
   end
 end
 
 sudo 'passwd' do
   user 'passwd'
   nopasswd false
+  defaults ['!requiretty']
+end
+
+sudo 'reqtty' do
+  user 'reqtty'
+  nopasswd true
+  defaults ['requiretty']
 end
 
 # execute tests
@@ -61,7 +69,7 @@ execute 'run ssh tests' do
   cwd '/tmp/kitchen/data'
 end
 
-%w{passwd nopasswd}.each do |name|
+%w{passwd nopasswd reqtty}.each do |name|
   execute "run local sudo tests as #{name}" do
     command "/opt/chef/embedded/bin/ruby -I lib test/integration/sudo/#{name}.rb"
     cwd '/tmp/kitchen/data'

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -76,3 +76,19 @@ end
     user name
   end
 end
+
+execute 'fix sudoers for reqtty' do
+  command 'chef-apply contrib/fixup_requiretty.rb'
+  cwd '/tmp/kitchen/data'
+  environment(
+    'TRAIN_SUDO_USER' => 'reqtty',
+    'TRAIN_SUDO_VERY_MUCH' => 'yes',
+  )
+end
+
+# if it's fixed, it should behave like user 'nopasswd'
+execute "run local sudo tests as reqtty, no longer requiring a tty" do
+  command "/opt/chef/embedded/bin/ruby -I lib test/integration/sudo/nopasswd.rb"
+  cwd '/tmp/kitchen/data'
+  user 'reqtty'
+end

--- a/test/integration/sudo/reqtty.rb
+++ b/test/integration/sudo/reqtty.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+# author: Stephan Renatus
+
+require_relative 'run_as'
+
+describe 'run_command' do
+  it 'is running as non-root without sudo' do
+    run_as('whoami').stdout.wont_match /root/i
+  end
+
+  it 'is throwing an error trying to use sudo' do
+    err = ->{ run_as('whoami', { sudo: true }) }.must_raise Train::UserError
+    err.message.must_match /Sudo failed: Sudo requires a TTY. Please see the README/i
+  end
+end


### PR DESCRIPTION
This change includes a `chef-apply`able recipe stub that can be used to fix a user's `sudoers` config if the distribution defaults to `requiretty`.

```interactive
# TRAIN_SUDO_USER=chef chef-apply contrib/fixup-requiretty.rb
```

It tries to be cautious, since sudoer configurations are a delicate matter.