### PR TITLE
complete rewrite of windows version detection

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,8 @@ clone_folder: c:\projects\train
 clone_depth: 1
 
 cache:
-  - C:\Ruby21\bin\gem
+  - C:\Users\appveyor\.gem\ruby\2.1.0
+  - C:\Ruby21\lib\ruby\gems\2.1.0
 
 install:
   - systeminfo
@@ -33,7 +34,6 @@ install:
   - ps: $env:PATH="C:\Ruby$env:ruby_version\bin;$env:PATH"
   - ps: Write-Host $env:PATH
   - gem install bundler --quiet --no-ri --no-rdoc
-  - gem update --system 2.4.5
   - ruby --version
   - gem --version
   - bundler --version

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -3,6 +3,7 @@
 # author: Christoph Hartmann
 
 require 'base64'
+require 'winrm'
 require 'train/errors'
 
 module Train::Extras

--- a/lib/train/extras/os_detect_windows.rb
+++ b/lib/train/extras/os_detect_windows.rb
@@ -24,7 +24,7 @@ module Train::Extras
         # release is 6.3.9600 now
         @platform[:release] = release[:name].downcase.gsub('version', '').strip
         # fallback, if we are not able to extract the name from wmic later
-        @platform[:name] = @platform[:release]
+        @platform[:name] = "Windows #{@platform[:release]}"
       end
 
       # try to use wmic, but lets keep it optional

--- a/test/unit/extras/os_detect_linux_test.rb
+++ b/test/unit/extras/os_detect_linux_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'helper'
 require 'train/extras'
 

--- a/test/unit/extras/os_detect_windows_test.rb
+++ b/test/unit/extras/os_detect_windows_test.rb
@@ -1,0 +1,99 @@
+require 'train/extras'
+
+class OsDetectWindowsTester
+  attr_reader :platform, :backend
+  include Train::Extras::DetectWindows
+
+  def initialize
+    @platform = {}
+    @backend = Train::Transports::Mock.new.connection
+    @backend.mock_os({ family: 'windows' })
+  end
+end
+
+describe 'os_detect_windows' do
+  describe 'windows 2012' do
+    let(:detector) {
+      detector = OsDetectWindowsTester.new
+      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.3.9600]\r\n", '', 0)
+      detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=9600\r\r\nCaption=Microsoft Windows Server 2012 R2 Standard\r\r\nOSArchitecture=64-bit\r\r\nVersion=6.3.9600\r\r\n" , '', 0)
+      detector
+    }
+
+    it 'sets the correct family/release for windows' do
+      detector.detect_windows
+      detector.platform[:family].must_equal('windows')
+      detector.platform[:name].must_equal('Windows Server 2012 R2 Standard')
+      detector.platform[:arch].must_equal('64-bit')
+      detector.platform[:release].must_equal('6.3.9600')
+    end
+  end
+
+  describe 'windows 2008' do
+    let(:detector) {
+      detector = OsDetectWindowsTester.new
+      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
+      detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=7601\r\r\nCaption=Microsoft Windows Server 2008 R2 Standard \r\r\nOSArchitecture=64-bit\r\r\nVersion=6.1.7601\r\r\n" , '', 0)
+      detector
+    }
+
+    it 'sets the correct family/release for windows' do
+      detector.detect_windows
+      detector.platform[:family].must_equal('windows')
+      detector.platform[:name].must_equal('Windows Server 2008 R2 Standard')
+      detector.platform[:arch].must_equal('64-bit')
+      detector.platform[:release].must_equal('6.1.7601')
+    end
+  end
+
+  describe 'windows 7' do
+    let(:detector) {
+      detector = OsDetectWindowsTester.new
+      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
+      detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=7601\r\r\nCaption=Microsoft Windows 7 Enterprise \r\r\nOSArchitecture=32-bit\r\r\nVersion=6.1.7601\r\r\n\r\r\n" , '', 0)
+      detector
+    }
+
+    it 'sets the correct family/release for windows' do
+      detector.detect_windows
+      detector.platform[:family].must_equal('windows')
+      detector.platform[:name].must_equal('Windows 7 Enterprise')
+      detector.platform[:arch].must_equal('32-bit')
+      detector.platform[:release].must_equal('6.1.7601')
+    end
+  end
+
+  describe 'windows 10' do
+    let(:detector) {
+      detector = OsDetectWindowsTester.new
+      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 10.0.10240]\r\n", '', 0)
+      detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=10240\r\r\nCaption=Microsoft Windows 10 Pro\r\r\nOSArchitecture=64-bit\r\r\nVersion=10.0.10240\r\r\n\r\r\n" , '', 0)
+      detector
+    }
+
+    it 'sets the correct family/release for windows' do
+      detector.detect_windows
+      detector.platform[:family].must_equal('windows')
+      detector.platform[:name].must_equal('Windows 10 Pro')
+      detector.platform[:arch].must_equal('64-bit')
+      detector.platform[:release].must_equal('10.0.10240')
+    end
+  end
+
+  describe 'windows 98' do
+    let(:detector) {
+      detector = OsDetectWindowsTester.new
+      detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 4.10.1998]\r\n", '', 0)
+      detector.backend.mock_command('wmic os get * /format:list', nil , '', 1)
+      detector
+    }
+
+    it 'fallback to version number if wmic is not available' do
+      detector.detect_windows
+      detector.platform[:family].must_equal('windows')
+      detector.platform[:name].must_equal('4.10.1998')
+      detector.platform[:arch].must_equal(nil)
+      detector.platform[:release].must_equal('4.10.1998')
+    end
+  end
+end

--- a/test/unit/extras/os_detect_windows_test.rb
+++ b/test/unit/extras/os_detect_windows_test.rb
@@ -91,7 +91,7 @@ describe 'os_detect_windows' do
     it 'fallback to version number if wmic is not available' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
-      detector.platform[:name].must_equal('4.10.1998')
+      detector.platform[:name].must_equal('Windows 4.10.1998')
       detector.platform[:arch].must_equal(nil)
       detector.platform[:release].must_equal('4.10.1998')
     end

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -21,10 +21,10 @@ describe 'windows local command' do
 
   it 'verify os' do
     os = conn.os
-    os[:name].must_equal nil
+    os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
     os[:family].must_equal "windows"
-    os[:release].must_equal "Server 2012 R2"
-    os[:arch].must_equal nil
+    os[:release].must_equal '6.3.9600'
+    os[:arch].must_equal '64-bit'
   end
 
   it 'run echo test' do

--- a/test/windows/winrm_test.rb
+++ b/test/windows/winrm_test.rb
@@ -27,10 +27,10 @@ describe 'windows local command' do
 
   it 'verify os' do
     os = conn.os
-    os[:name].must_equal nil
-    os[:family].must_equal "windows"
-    os[:release].must_equal "Server 2012 R2"
-    os[:arch].must_equal nil
+    os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
+    os[:family].must_equal 'windows'
+    os[:release].must_equal '6.3.9600'
+    os[:arch].must_equal '64-bit'
   end
 
   it 'run echo test' do


### PR DESCRIPTION
The new Windows version detection is not based on Powershell anymore, it uses two core commands:
- `ver` is a command-line tool since MSDOS that outputs the version of the Operating System
- ~~`systeminfo` was introduced in Windows XP Professional and outputs more system details~~
- `wmic os get * /format:list` to retrieve the details of the operating system

Unfortunately we cannot rely on `ver` only, since build numbers and version are sometimes the same between Windows Client and Server. Therefore we cannot use this alone to distinguish between both operating systems.