### PR TITLE
depend on docker-api 1.26.2

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'net-scp', '~> 1.2'
   spec.add_dependency 'winrm', '~> 1.6'
   spec.add_dependency 'winrm-fs', '~> 0.3'
-  spec.add_dependency 'docker-api', '~> 1.22'
+  spec.add_dependency 'docker-api', '~> 1.26.2'
 
   spec.add_development_dependency 'mocha', '~> 1.1'
 end


### PR DESCRIPTION
This fixes a bug that breaks Docker 1.10.x