### PR TITLE
add -L to get stat for symlink

### DIFF
--- a/lib/train/extras/stat.rb
+++ b/lib/train/extras/stat.rb
@@ -34,7 +34,7 @@ module Train::Extras
     end
 
     def self.linux_stat(shell_escaped_path, backend)
-      res = backend.run_command("stat #{shell_escaped_path} 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'")
+      res = backend.run_command("stat -L #{shell_escaped_path} 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'")
 
       # ignore the exit_code: it is != 0 if selinux labels are not supported
       # on the system.
@@ -73,7 +73,7 @@ module Train::Extras
       #      ...
       #      gu      Display group or user name.
       res = backend.run_command(
-        "stat -f '%z\n%p\n%Su\n%u\n%Sg\n%g\n%a\n%m' "\
+        "stat -Lf '%z\n%p\n%Su\n%u\n%Sg\n%g\n%a\n%m' "\
         "#{shell_escaped_path}")
 
       return {} if res.exit_status != 0

--- a/test/unit/extras/linux_file_test.rb
+++ b/test/unit/extras/linux_file_test.rb
@@ -13,7 +13,7 @@ describe 'file common' do
 
   def mock_stat(path, out, err = '', code = 0)
     backend.mock_command(
-      "stat path 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'",
+      "stat -L path 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'",
       out, err, code,
     )
   end


### PR DESCRIPTION
Fixes https://github.com/chef/inspec/issues/665

Tested on centos6, BSD.
Looks like aix is already using the lstat command, but I don't really know how to go about testing it. didn't change anything there.
When I tested, I confirmed that it now reads perms correctly for test referenced in the issue and also confirmed it did not modify the results of any other test.