### PR TITLE
Overhault file(...) and stat(...); point to destination of symlinks

### DIFF
--- a/lib/train/extras/file_common.rb
+++ b/lib/train/extras/file_common.rb
@@ -10,7 +10,7 @@ module Train::Extras
     # interface methods: these fields should be implemented by every
     # backend File
     %w{
-      exist? mode owner group link_target link_path content mtime size
+      exist? mode owner group link_path content mtime size
       selinux_label product_version file_version path
     }.each do |m|
       define_method m.to_sym do
@@ -126,8 +126,6 @@ module Train::Extras
     def target_type
       # Just return the type unless this is a symlink
       return type unless type == :symlink
-      # Get the link's target type, i.e. the real destination's type
-      return link_target.type unless link_target.nil?
       # Return unknown if we don't know where this is pointing to
       :unknown
     end

--- a/lib/train/extras/file_common.rb
+++ b/lib/train/extras/file_common.rb
@@ -10,7 +10,7 @@ module Train::Extras
     # interface methods: these fields should be implemented by every
     # backend File
     %w{
-      exist? mode owner group content mtime size selinux_label path
+      exist? mode owner group uid gid content mtime size selinux_label path
       product_version file_version
     }.each do |m|
       define_method m.to_sym do
@@ -99,6 +99,10 @@ module Train::Extras
 
     def linked_to?(dst)
       link_path == dst
+    end
+
+    def link_path
+      symlink? ? path : nil
     end
 
     def version?(version)

--- a/lib/train/extras/file_unix.rb
+++ b/lib/train/extras/file_unix.rb
@@ -8,9 +8,8 @@ require 'train/extras/stat'
 module Train::Extras
   class UnixFile < FileCommon
     attr_reader :path
-    def initialize(backend, path)
-      @backend = backend
-      @path = path
+    def initialize(backend, path, follow_symlink = true)
+      super(backend, path, follow_symlink)
       @spath = Shellwords.escape(@path)
     end
 
@@ -27,25 +26,15 @@ module Train::Extras
 
     def exist?
       @exist ||= (
-        @backend.run_command("test -e #{@spath}")
+        f = @follow_symlink ? '' : " || test -L #{@spath}"
+        @backend.run_command("test -e #{@spath}"+f)
                 .exit_status == 0
       )
     end
 
-    # Returns full path of a symlink target(real dest) or '' on symlink loop
-    def get_target_path
-      full_path = @backend.run_command("readlink -n #{@spath} -f").stdout
-      # Needed for some OSes like OSX that returns relative path
-      # when the link and target are in the same directory
-      if !full_path.start_with?('/') && full_path != ''
-        full_path = File.expand_path("../#{full_path}", @spath)
-      end
-      full_path
-    end
-
-    def link_path
-      return nil unless symlink?
-      @link_path ||= get_target_path
+    def path
+      return @path unless @follow_symlink && symlink?
+      @link_path ||= read_target_path
     end
 
     def mounted
@@ -71,7 +60,20 @@ module Train::Extras
 
     def stat
       return @stat if defined?(@stat)
-      @stat = Train::Extras::Stat.stat(@spath, @backend)
+      @stat = Train::Extras::Stat.stat(@spath, @backend, @follow_symlink)
+    end
+
+    private
+
+    # Returns full path of a symlink target(real dest) or '' on symlink loop
+    def read_target_path
+      full_path = @backend.run_command("readlink -n #{@spath} -f").stdout
+      # Needed for some OSes like OSX that returns relative path
+      # when the link and target are in the same directory
+      if !full_path.start_with?('/') && full_path != ''
+        full_path = File.expand_path("../#{full_path}", @spath)
+      end
+      full_path
     end
   end
 end

--- a/lib/train/extras/file_unix.rb
+++ b/lib/train/extras/file_unix.rb
@@ -43,7 +43,7 @@ module Train::Extras
     end
 
     %w{
-      type mode owner group mtime size selinux_label
+      type mode owner group uid gid mtime size selinux_label
     }.each do |field|
       define_method field.to_sym do
         stat[field.to_sym]

--- a/lib/train/extras/file_windows.rb
+++ b/lib/train/extras/file_windows.rb
@@ -44,10 +44,6 @@ module Train::Extras
         "(Test-Path -Path \"#{@spath}\").ToString()").stdout.chomp == 'True'
     end
 
-    def link_target
-      nil
-    end
-
     def link_path
       nil
     end
@@ -57,7 +53,7 @@ module Train::Extras
     end
 
     def type
-      :unknown
+      target_type
     end
 
     %w{
@@ -85,7 +81,7 @@ module Train::Extras
     def attributes
       return @attributes if defined?(@attributes)
       @attributes = @backend.run_command(
-        "(Get-ItemProperty -Path \"#{@spath}\").attributes.ToString()").stdout.chomp.split(',')
+        "(Get-ItemProperty -Path \"#{@spath}\").attributes.ToString()").stdout.chomp.split(/\s*,\s*/)
     end
 
     def target_type

--- a/lib/train/extras/file_windows.rb
+++ b/lib/train/extras/file_windows.rb
@@ -61,7 +61,7 @@ module Train::Extras
     end
 
     %w{
-      mode owner group mtime size selinux_label
+      mode owner group uid gid mtime size selinux_label
     }.each do |field|
       define_method field.to_sym do
         nil

--- a/lib/train/extras/file_windows.rb
+++ b/lib/train/extras/file_windows.rb
@@ -11,9 +11,8 @@ require 'train/extras/stat'
 module Train::Extras
   class WindowsFile < FileCommon
     attr_reader :path
-    def initialize(backend, path)
-      @backend = backend
-      @path = path
+    def initialize(backend, path, follow_symlink)
+      super(backend, path, follow_symlink)
       @spath = sanitize_filename(@path)
     end
 
@@ -53,7 +52,12 @@ module Train::Extras
     end
 
     def type
-      target_type
+      if attributes.include?('Archive')
+        return :file
+      elsif attributes.include?('Directory')
+        return :directory
+      end
+      :unknown
     end
 
     %w{
@@ -82,15 +86,6 @@ module Train::Extras
       return @attributes if defined?(@attributes)
       @attributes = @backend.run_command(
         "(Get-ItemProperty -Path \"#{@spath}\").attributes.ToString()").stdout.chomp.split(/\s*,\s*/)
-    end
-
-    def target_type
-      if attributes.include?('Archive')
-        return :file
-      elsif attributes.include?('Directory')
-        return :directory
-      end
-      :unknown
     end
   end
 end

--- a/lib/train/extras/stat.rb
+++ b/lib/train/extras/stat.rb
@@ -19,22 +19,23 @@ module Train::Extras
       res.nil? ? :unknown : res[0]
     end
 
-    def self.stat(shell_escaped_path, backend)
+    def self.stat(shell_escaped_path, backend, follow_symlink)
       # use perl scripts for aix and solaris 10
       if backend.os.aix? || (backend.os.solaris? && backend.os[:release].to_i < 11)
-        return aix_stat(shell_escaped_path, backend)
+        return aix_stat(shell_escaped_path, backend, follow_symlink)
       end
-      return bsd_stat(shell_escaped_path, backend) if backend.os.bsd?
+      return bsd_stat(shell_escaped_path, backend, follow_symlink) if backend.os.bsd?
       # linux and solaris 11 will use standard linux stats
-      return linux_stat(shell_escaped_path, backend) if backend.os.unix?
+      return linux_stat(shell_escaped_path, backend, follow_symlink) if backend.os.unix?
       # all other cases we don't handle
       # TODO: print an error if we get here, as it shouldn't be invoked
       # on non-unix
       {}
     end
 
-    def self.linux_stat(shell_escaped_path, backend)
-      res = backend.run_command("stat #{shell_escaped_path} 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'")
+    def self.linux_stat(shell_escaped_path, backend, follow_symlink)
+      lstat = follow_symlink ? '-L' : ''
+      res = backend.run_command("stat #{lstat} #{shell_escaped_path} 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'")
 
       # ignore the exit_code: it is != 0 if selinux labels are not supported
       # on the system.
@@ -57,7 +58,7 @@ module Train::Extras
       }
     end
 
-    def self.bsd_stat(shell_escaped_path, backend)
+    def self.bsd_stat(shell_escaped_path, backend, follow_symlink)
       # From stat man page on FreeBSD:
       # z       The size of file in bytes (st_size).
       # p       File type and permissions (st_mode).
@@ -72,8 +73,9 @@ module Train::Extras
       # in combination with:
       #      ...
       #      gu      Display group or user name.
+      lstat = follow_symlink ? '-L' : ''
       res = backend.run_command(
-        "stat -f '%z\n%p\n%Su\n%u\n%Sg\n%g\n%a\n%m' "\
+        "stat #{lstat} -f '%z\n%p\n%Su\n%u\n%Sg\n%g\n%a\n%m' "\
         "#{shell_escaped_path}")
 
       return {} if res.exit_status != 0
@@ -94,11 +96,12 @@ module Train::Extras
       }
     end
 
-    def self.aix_stat(shell_escaped_path, backend)
+    def self.aix_stat(shell_escaped_path, backend, follow_symlink)
       # Perl here b/c it is default on AIX
+      lstat = follow_symlink ? 'lstat' : 'stat'
       stat_cmd = <<-EOP
       perl -e '
-      @a = lstat(shift) or exit 2;
+      @a = #{lstat}(shift) or exit 2;
       $u = getpwuid($a[4]);
       $g = getgrgid($a[5]);
       printf("0%o\\n%s\\n%s\\n%d\\n%d\\n", $a[2], $u, $g, $a[9], $a[7])

--- a/lib/train/transports/local_file.rb
+++ b/lib/train/transports/local_file.rb
@@ -23,7 +23,12 @@ class Train::Transports::Local::Connection
 
     def link_path
       return nil unless symlink?
-      @link_path ||= ::File.readlink(@path)
+      begin
+        @link_path ||= ::File.realpath(@path)
+      rescue Errno::ELOOP => e
+        # Leave it blank on symbolic loop, same as readlink
+        @link_path = ''
+      end
     end
 
     def block_device?

--- a/lib/train/transports/local_file.rb
+++ b/lib/train/transports/local_file.rb
@@ -25,7 +25,7 @@ class Train::Transports::Local::Connection
       return nil unless symlink?
       begin
         @link_path ||= ::File.realpath(@path)
-      rescue Errno::ELOOP => e
+      rescue Errno::ELOOP => _
         # Leave it blank on symbolic loop, same as readlink
         @link_path = ''
       end
@@ -73,11 +73,13 @@ class Train::Transports::Local::Connection
         mtime: file_stat.mtime.to_i,
         size: file_stat.size,
         owner: pw_username(file_stat.uid),
+        uid: file_stat.uid,
         group: pw_groupname(file_stat.gid),
+        gid: file_stat.gid,
       }
 
-      lstat = @follow_symlink ? '-L' : ''
-      res = @backend.run_command("stat #{lstat} #{@spath} 2>/dev/null --printf '%C'")
+      lstat = @follow_symlink ? ' -L' : ''
+      res = @backend.run_command("stat#{lstat} #{@spath} 2>/dev/null --printf '%C'")
       if res.exit_status == 0 && !res.stdout.empty? && res.stdout != '?'
         @stat[:selinux_label] = res.stdout.strip
       end

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -127,7 +127,7 @@ end
 class Train::Transports::Mock::Connection
   class File < FileCommon
     %w{
-      exist? mode owner group link_target link_path content mtime size
+      exist? mode owner group link_path content mtime size
       selinux_label product_version file_version path type
     }.each do |m|
       attr_accessor m.tr('?', '').to_sym

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -133,16 +133,15 @@ class Train::Transports::Mock::Connection
       attr_accessor m.tr('?', '').to_sym
     end
 
-    def initialize(runtime, path)
-      @path = path
+    def initialize(backend, path, follow_symlink = true)
+      super(backend, path, follow_symlink)
       @type = :unknown
       @exist = false
-      @runtime = runtime
     end
 
     def mounted
       @mounted ||=
-        @runtime.run_command("mount | grep -- ' on #{@path}'")
+        @backend.run_command("mount | grep -- ' on #{@path}'")
     end
   end
 end

--- a/test/integration/tests/path_symlink_test.rb
+++ b/test/integration/tests/path_symlink_test.rb
@@ -22,8 +22,8 @@ describe 'file interface' do
       file.directory?.must_equal(false)
     end
 
-    it 'has type :symlink' do
-      file.type.must_equal(:symlink)
+    it 'has type :file' do
+      file.type.must_equal(:file)
     end
 
     it 'has content' do
@@ -34,16 +34,28 @@ describe 'file interface' do
       file.owner.must_equal('root')
     end
 
+    it 'has uid 0' do
+      file.uid.must_equal(0)
+    end
+
     it 'has group name' do
       file.group.must_equal(Test.root_group(backend.os))
     end
 
-    it 'has mode 0777' do
-      file.mode.must_equal(00777)
+    it 'has gid 0' do
+      file.gid.must_equal(0)
     end
 
-    it 'checks mode? 0777' do
-      file.mode?(00777).must_equal(true)
+    it 'has mode 0777' do
+      file.source.mode.must_equal(00777)
+    end
+
+    it 'has mode 0765' do
+      file.mode.must_equal(00765)
+    end
+
+    it 'checks mode? 0765' do
+      file.mode?(00765).must_equal(true)
     end
 
     it 'has link_path' do

--- a/test/unit/extras/file_common_test.rb
+++ b/test/unit/extras/file_common_test.rb
@@ -5,6 +5,7 @@ require 'train/extras/file_common'
 
 describe 'file common' do
   let(:cls) { Train::Extras::FileCommon }
+  let(:new_cls) { cls.new(nil, nil, false) }
 
   def mockup(stubs)
     Class.new(cls) do
@@ -13,35 +14,35 @@ describe 'file common' do
           v
         end
       end
-    end.new
+    end.new(nil, nil, false)
   end
 
   it 'has the default type of unknown' do
-    cls.new.type.must_equal :unknown
+    new_cls.type.must_equal :unknown
   end
 
   it 'calculates md5sum from content' do
     content = 'hello world'
-    cls.new.stub :content, content do |i|
+    new_cls.stub :content, content do |i|
       i.md5sum.must_equal '5eb63bbbe01eeed093cb22bb8f5acdc3'
     end
   end
 
   it 'sets md5sum of nil content to nil' do
-    cls.new.stub :content, nil do |i|
+    new_cls.stub :content, nil do |i|
       i.md5sum.must_be_nil
     end
   end
 
   it 'calculates md5sum from content' do
     content = 'hello world'
-    cls.new.stub :content, content do |i|
+    new_cls.stub :content, content do |i|
       i.sha256sum.must_equal 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
     end
   end
 
   it 'sets sha256sum of nil content to nil' do
-    cls.new.stub :content, nil do |i|
+    new_cls.stub :content, nil do |i|
       i.sha256sum.must_be_nil
     end
   end

--- a/test/unit/extras/linux_file_test.rb
+++ b/test/unit/extras/linux_file_test.rb
@@ -51,16 +51,8 @@ describe 'file common' do
   it 'retrieves the link path' do
     out = rand.to_s
     mock_stat('path', "13\na1ff\nz\n1001\nz\n1001\n1444573475\n1444573475\n?")
-    backend.mock_command('readlink path', out)
-    cls.new(backend, 'path').link_path.must_equal out
-  end
-
-  it 'retrieves the linked file' do
-    out = rand.to_s
-    mock_stat('path', "13\na1ff\nz\n1001\nz\n1001\n1444573475\n1444573475\n?")
-    backend.mock_command('readlink path', out)
-    f = backend.file(out)
-    cls.new(backend, 'path').link_target.must_equal f
+    backend.mock_command('readlink -n path -f', out)
+    cls.new(backend, 'path').link_path.must_equal File.join(Dir.pwd, out)
   end
 
   it 'checks a mounted path' do

--- a/test/unit/extras/linux_file_test.rb
+++ b/test/unit/extras/linux_file_test.rb
@@ -11,9 +11,9 @@ describe 'file common' do
     backend
   }
 
-  def mock_stat(path, out, err = '', code = 0)
+  def mock_stat(args, out, err = '', code = 0)
     backend.mock_command(
-      "stat path 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'",
+      "stat #{args} 2>/dev/null --printf '%s\n%f\n%U\n%u\n%G\n%g\n%X\n%Y\n%C'",
       out, err, code,
     )
   end
@@ -34,7 +34,7 @@ describe 'file common' do
 
   it 'reads file contents' do
     backend.mock_command('cat path || echo -n', '')
-    mock_stat('path', '', 'some error...', 1)
+    mock_stat('-L path', '', 'some error...', 1)
     cls.new(backend, 'path').content.must_equal nil
   end
 
@@ -69,30 +69,84 @@ describe 'file common' do
   end
 
   describe 'stat on a file' do
-    before { mock_stat('path', "13\na1ff\nz\n1001\nz\n1001\n1444573475\n1444573475\nlabels") }
+    before { mock_stat('-L path', "13\na1ff\nz\n1001\nz2\n1002\n1444573475\n1444573475\nlabels") }
+    let(:f) { cls.new(backend, 'path') }
 
     it 'retrieves the file type' do
-      cls.new(backend, 'path').type.must_equal :symlink
+      f.type.must_equal :symlink
     end
 
     it 'retrieves the file mode' do
-      cls.new(backend, 'path').mode.must_equal 00777
+      f.mode.must_equal 00777
     end
 
     it 'retrieves the file owner' do
-      cls.new(backend, 'path').owner.must_equal 'z'
+      f.owner.must_equal 'z'
+    end
+
+    it 'retrieves the file uid' do
+      f.uid.must_equal 1001
+    end
+
+    it 'retrieves the file group' do
+      f.group.must_equal 'z2'
+    end
+
+    it 'retrieves the file gid' do
+      f.gid.must_equal 1002
     end
 
     it 'retrieves the file mtime' do
-      cls.new(backend, 'path').mtime.must_equal 1444573475
+      f.mtime.must_equal 1444573475
     end
 
     it 'retrieves the file size' do
-      cls.new(backend, 'path').size.must_equal 13
+      f.size.must_equal 13
     end
 
     it 'retrieves the file selinux_label' do
-      cls.new(backend, 'path').selinux_label.must_equal 'labels'
+      f.selinux_label.must_equal 'labels'
+    end
+  end
+
+  describe 'stat on the source file' do
+    before { mock_stat('path', "13\na1ff\nz\n1001\nz2\n1002\n1444573475\n1444573475\nlabels") }
+    let(:f) { cls.new(backend, 'path').source }
+
+    it 'retrieves the file type' do
+      f.type.must_equal :symlink
+    end
+
+    it 'retrieves the file mode' do
+      f.mode.must_equal 00777
+    end
+
+    it 'retrieves the file owner' do
+      f.owner.must_equal 'z'
+    end
+
+    it 'retrieves the file uid' do
+      f.uid.must_equal 1001
+    end
+
+    it 'retrieves the file group' do
+      f.group.must_equal 'z2'
+    end
+
+    it 'retrieves the file gid' do
+      f.gid.must_equal 1002
+    end
+
+    it 'retrieves the file mtime' do
+      f.mtime.must_equal 1444573475
+    end
+
+    it 'retrieves the file size' do
+      f.size.must_equal 13
+    end
+
+    it 'retrieves the file selinux_label' do
+      f.selinux_label.must_equal 'labels'
     end
   end
 end

--- a/test/unit/extras/stat_test.rb
+++ b/test/unit/extras/stat_test.rb
@@ -48,19 +48,21 @@ describe 'stat' do
       res = Minitest::Mock.new
       res.expect :stdout, ''
       backend.expect :run_command, res, [String]
-      cls.linux_stat('/path', backend).must_equal({})
+      cls.linux_stat('/path', backend, false).must_equal({})
     end
 
     it 'reads correct stat results' do
       res = Minitest::Mock.new
       # 43ff is 41777; linux_stat strips the 4
-      res.expect :stdout, "360\n43ff\nroot\n0\nroot\n0\n1444520846\n1444522445\n?"
+      res.expect :stdout, "360\n43ff\nroot\n0\nrootz\n1\n1444520846\n1444522445\n?"
       backend.expect :run_command, res, [String]
-      cls.linux_stat('/path', backend).must_equal({
+      cls.linux_stat('/path', backend, false).must_equal({
         type: :directory,
         mode: 01777,
         owner: 'root',
-        group: 'root',
+        uid: 0,
+        group: 'rootz',
+        gid: 1,
         mtime: 1444522445,
         size: 360,
         selinux_label: nil,
@@ -76,7 +78,7 @@ describe 'stat' do
       res.expect :stdout, '.....'
       res.expect :exit_status, 1
       backend.expect :run_command, res, [String]
-      cls.bsd_stat('/path', backend).must_equal({})
+      cls.bsd_stat('/path', backend, false).must_equal({})
     end
 
     it 'ignores wrong stat results' do
@@ -84,19 +86,21 @@ describe 'stat' do
       res.expect :stdout, ''
       res.expect :exit_status, 0
       backend.expect :run_command, res, [String]
-      cls.bsd_stat('/path', backend).must_equal({})
+      cls.bsd_stat('/path', backend, false).must_equal({})
     end
 
     it 'reads correct stat results' do
       res = Minitest::Mock.new
-      res.expect :stdout, "360\n41777\nroot\n0\nroot\n0\n1444520846\n1444522445"
+      res.expect :stdout, "360\n41777\nroot\n0\nrootz\n1\n1444520846\n1444522445"
       res.expect :exit_status, 0
       backend.expect :run_command, res, [String]
-      cls.bsd_stat('/path', backend).must_equal({
+      cls.bsd_stat('/path', backend, false).must_equal({
         type: :directory,
         mode: 01777,
         owner: 'root',
-        group: 'root',
+        uid: 0,
+        group: 'rootz',
+        gid: 1,
         mtime: 1444522445,
         size: 360,
         selinux_label: nil,

--- a/test/unit/extras/windows_file_test.rb
+++ b/test/unit/extras/windows_file_test.rb
@@ -12,15 +12,15 @@ describe 'file common' do
   }
 
   it 'provides the full path' do
-    cls.new(backend, 'C:\dir\file').path.must_equal 'C:\dir\file'
+    cls.new(backend, 'C:\dir\file', false).path.must_equal 'C:\dir\file'
   end
 
   it 'provides the basename to a unix path' do
-    cls.new(backend, 'C:\dir\file').basename.must_equal 'file'
+    cls.new(backend, 'C:\dir\file', false).basename.must_equal 'file'
   end
 
   it 'provides the full path with whitespace' do
-    wf = cls.new(backend, 'C:\Program Files\file name')
+    wf = cls.new(backend, 'C:\Program Files\file name', false)
     wf.path.must_equal 'C:\Program Files\file name'
     wf.basename.must_equal 'file name'
   end
@@ -28,11 +28,11 @@ describe 'file common' do
   it 'reads file contents' do
     out = rand.to_s
     backend.mock_command('Get-Content("path") | Out-String', out)
-    cls.new(backend, 'path').content.must_equal out
+    cls.new(backend, 'path', false).content.must_equal out
   end
 
   it 'check escaping of invalid chars in path' do
-    wf = cls.new(nil, nil)
+    wf = cls.new(nil, nil, false)
     wf.sanitize_filename('c:/test') .must_equal 'c:/test'
     wf.sanitize_filename('c:/test directory') .must_equal 'c:/test directory'
     %w{ < > " * ?}.each do |char|

--- a/test/unit/transports/local_file_test.rb
+++ b/test/unit/transports/local_file_test.rb
@@ -42,7 +42,7 @@ describe 'local file transport' do
 
   it 'checks a file\'s link path' do
     out = rand.to_s
-    File.stub :readlink, out do
+    File.stub :realpath, out do
       File.stub :symlink?, true do
         connection.file(rand.to_s).link_path.must_equal out
       end

--- a/test/unit/transports/local_file_test.rb
+++ b/test/unit/transports/local_file_test.rb
@@ -51,7 +51,9 @@ describe 'local file transport' do
 
   describe 'file metadata' do
     let(:stat) { Struct.new(:mode, :size, :mtime, :uid, :gid) }
-    let(:statres) { stat.new(00140755, rand, (rand*100).to_i, rand, rand) }
+    let(:uid) { rand }
+    let(:gid) { rand }
+    let(:statres) { stat.new(00140755, rand, (rand*100).to_i, uid, gid) }
 
     def meta_stub(method, param, &block)
       pwres = Struct.new(:name)
@@ -63,47 +65,117 @@ describe 'local file transport' do
     end
 
     it 'recognizes type' do
-      meta_stub :lstat, statres do
+      meta_stub :stat, statres do
         connection.file(rand.to_s).type.must_equal :socket
       end
     end
 
     it 'recognizes mode' do
-      meta_stub :lstat, statres do
+      meta_stub :stat, statres do
         connection.file(rand.to_s).mode.must_equal 00755
       end
     end
 
     it 'recognizes mtime' do
-      meta_stub :lstat, statres do
+      meta_stub :stat, statres do
         connection.file(rand.to_s).mtime.must_equal statres.mtime
       end
     end
 
     it 'recognizes size' do
-      meta_stub :lstat, statres do
+      meta_stub :stat, statres do
         connection.file(rand.to_s).size.must_equal statres.size
       end
     end
 
     it 'recognizes owner' do
-      meta_stub :lstat, statres do
+      meta_stub :stat, statres do
         connection.file(rand.to_s).owner.must_equal 'owner'
       end
     end
 
+    it 'recognizes uid' do
+      meta_stub :stat, statres do
+        connection.file(rand.to_s).uid.must_equal uid
+      end
+    end
+
     it 'recognizes group' do
-      meta_stub :lstat, statres do
+      meta_stub :stat, statres do
         connection.file(rand.to_s).group.must_equal 'group'
       end
     end
 
+    it 'recognizes gid' do
+      meta_stub :stat, statres do
+        connection.file(rand.to_s).gid.must_equal gid
+      end
+    end
+
     it 'recognizes selinux label' do
-      meta_stub :lstat, statres do
+      meta_stub :stat, statres do
         label = rand.to_s
         res = Train::Extras::CommandResult.new(label, nil, 0)
         connection.stub :run_command, res do
           connection.file(rand.to_s).selinux_label.must_equal label
+        end
+      end
+    end
+
+    it 'recognizes source type' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.type.must_equal :socket
+      end
+    end
+
+    it 'recognizes source mode' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.mode.must_equal 00755
+      end
+    end
+
+    it 'recognizes source mtime' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.mtime.must_equal statres.mtime
+      end
+    end
+
+    it 'recognizes source size' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.size.must_equal statres.size
+      end
+    end
+
+    it 'recognizes source owner' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.owner.must_equal 'owner'
+      end
+    end
+
+    it 'recognizes source uid' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.uid.must_equal uid
+      end
+    end
+
+    it 'recognizes source owner' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.owner.must_equal 'owner'
+      end
+    end
+
+    it 'recognizes source gid' do
+      meta_stub :lstat, statres do
+        connection.file(rand.to_s).source.gid.must_equal gid
+      end
+    end
+
+    it 'recognizes source selinux label' do
+      meta_stub :lstat, statres do
+        label = rand.to_s
+        res = Train::Extras::CommandResult.new(label, nil, 0)
+        connection.stub :run_command, res do
+          connection.file(rand.to_s).source.selinux_label.must_equal label
         end
       end
     end


### PR DESCRIPTION
As started by @alexpop and input from @vjeffrey , kudos!!

Right now, train's file implementation will always only look at the file under consideration, even if it is a symlink. If you want to check, if e.g. `/my/link` is being owned by `user`, it would only tell you if the symlink you specified is owned this way, but not if the destination it points to has the right permissions. It was also inconsistent internally, since `/dev/stdout` is `character_device?`, which cannot be determined from the source file you specified, but only from the destination it points to. Train did internally resolve this conflict for any type checks, but not for access permissions or anything else originating in `stat`.

After a lot of internal discussions we came to the conclusion, that the interface we are most interested in for testing any of these files would be pointing to the destination, not the source. If I wanted to know if `/dev/stdout` is a `symlink?` or owned by `root`, it would test that against wherever that file points to.

This also means, that there must be an accessor to give me the symlink only. While we have `link_path`, we also needed an object to run permissions checks. We decided against `link_source`, as it would only work consistently, when applied to links; similar to how `link_path` works right now:

```ruby
file('/dev/stdout').link_path => '/dev/fd/1'
file('/root').link_path => nil
```

Instead of `link_source` we opted for `source` with this mechanism:

```ruby
file('/dev/stdout').source => essentially file('/dev/stdout')
file('/root').link_path => essentially file('/root')
```

see:

![train stat-v-lstat](https://cloud.githubusercontent.com/assets/1307529/14891401/808c781a-0d34-11e6-9477-ea80fa80566c.png)

There is still some work to be done on `link_path` to make it follow to the final target on all OS's (OS X is the issue right now, due to the lack of `readlink -f` by default).