### PR TITLE
fix nil file paths

### DIFF
--- a/lib/train/extras/file_common.rb
+++ b/lib/train/extras/file_common.rb
@@ -20,7 +20,7 @@ module Train::Extras
 
     def initialize(backend, path, follow_symlink = true)
       @backend = backend
-      @path = path
+      @path = path || ''
       @follow_symlink = follow_symlink
     end
 

--- a/test/unit/extras/linux_file_test.rb
+++ b/test/unit/extras/linux_file_test.rb
@@ -18,6 +18,10 @@ describe 'file common' do
     )
   end
 
+  it 'works on nil path' do
+    cls.new(backend, nil).path.must_equal ''
+  end
+
   it 'provides the full path' do
     cls.new(backend, '/dir/file').path.must_equal '/dir/file'
   end


### PR DESCRIPTION
The problem with nil file paths is, that (a) they don't make any sense at all, but are contextually equal to `''` (empty string) and (b) they break a number of upstream methods like `File` in ruby. Since these are equivalent to `''` in all other regards (afaics), let's handle this case early on.

This is not trying to replace any other sources of input like numbers, non-string base types or even class instances. They should remain as e.g. custom file names could potentially prove dangerous. It's also easier to track down.