### PR TITLE
bugfix: windows file failed to initialize with new symlink handler

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,10 @@ environment:
   winrm_pass: Pass@word1
 
   matrix:
-    - ruby_version: "21"
+    - ruby_version: "22"
       train_target: winrm://test_user@localhost:5985
 
-    - ruby_version: "21"
+    - ruby_version: "22"
       train_ssl: true
       train_target: winrm://test_user@localhost:5986
 
@@ -20,8 +20,10 @@ clone_folder: c:\projects\train
 clone_depth: 1
 
 cache:
-  - C:\Users\appveyor\.gem\ruby\2.1.0
-  - C:\Ruby21\lib\ruby\gems\2.1.0
+  - C:\Users\appveyor\.gem\ruby\2.2.0
+  - C:\Ruby200-x64\bin\gem
+  - C:\Ruby22\bin\gem
+  - C:\Ruby22\lib\ruby\gems\2.2.0
 
 install:
   - systeminfo

--- a/lib/train/extras/file_windows.rb
+++ b/lib/train/extras/file_windows.rb
@@ -11,7 +11,7 @@ require 'train/extras/stat'
 module Train::Extras
   class WindowsFile < FileCommon
     attr_reader :path
-    def initialize(backend, path, follow_symlink)
+    def initialize(backend, path, follow_symlink = false)
       super(backend, path, follow_symlink)
       @spath = sanitize_filename(@path)
     end

--- a/test/unit/extras/windows_file_test.rb
+++ b/test/unit/extras/windows_file_test.rb
@@ -12,15 +12,15 @@ describe 'file common' do
   }
 
   it 'provides the full path' do
-    cls.new(backend, 'C:\dir\file', false).path.must_equal 'C:\dir\file'
+    cls.new(backend, 'C:\dir\file').path.must_equal 'C:\dir\file'
   end
 
   it 'provides the basename to a unix path' do
-    cls.new(backend, 'C:\dir\file', false).basename.must_equal 'file'
+    cls.new(backend, 'C:\dir\file').basename.must_equal 'file'
   end
 
   it 'provides the full path with whitespace' do
-    wf = cls.new(backend, 'C:\Program Files\file name', false)
+    wf = cls.new(backend, 'C:\Program Files\file name')
     wf.path.must_equal 'C:\Program Files\file name'
     wf.basename.must_equal 'file name'
   end
@@ -28,11 +28,11 @@ describe 'file common' do
   it 'reads file contents' do
     out = rand.to_s
     backend.mock_command('Get-Content("path") | Out-String', out)
-    cls.new(backend, 'path', false).content.must_equal out
+    cls.new(backend, 'path').content.must_equal out
   end
 
   it 'check escaping of invalid chars in path' do
-    wf = cls.new(nil, nil, false)
+    wf = cls.new(nil, nil)
     wf.sanitize_filename('c:/test') .must_equal 'c:/test'
     wf.sanitize_filename('c:/test directory') .must_equal 'c:/test directory'
     %w{ < > " * ?}.each do |char|


### PR DESCRIPTION
Fixes:
```
inspec> f=file('c:\Users\vagrant')
ArgumentError: wrong number of arguments (2 for 3)
from /Users/apop/.chefdk/gem/ruby/2.1.0/gems/r-train-0.11.1/lib/train/extras/file_windows.rb:14:in `initialize'
```