### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ train = Train.create('local')
 ```ruby
 require 'train'
 train = Train.create('ssh',
-  host: '1.2.3.4', port: 22, user: 'root', keys: '/vagrant')
+  host: '1.2.3.4', port: 22, user: 'root', key_files: '/vagrant')
 ```
 
 **WinRM**


### PR DESCRIPTION
The ssh option for identity files is `:key_files`, not `:keys`.