### PR TITLE
Add a space to avoid matching partial paths

### DIFF
--- a/lib/train/extras/file_unix.rb
+++ b/lib/train/extras/file_unix.rb
@@ -39,7 +39,7 @@ module Train::Extras
 
     def mounted
       @mounted ||=
-        @backend.run_command("mount | grep -- ' on #{@spath}'")
+        @backend.run_command("mount | grep -- ' on #{@spath} '")
     end
 
     %w{

--- a/test/unit/extras/linux_file_test.rb
+++ b/test/unit/extras/linux_file_test.rb
@@ -71,8 +71,8 @@ describe 'file common' do
   end
 
   it 'checks a mounted path' do
-    backend.mock_command("mount | grep -- ' on path'", rand.to_s)
-    cls.new(backend, 'path').mounted?.must_equal true
+    backend.mock_command("mount | grep -- ' on /mount/path '", rand.to_s)
+    cls.new(backend, '/mount/path').mounted?.must_equal true
   end
 
   it 'has nil product version' do


### PR DESCRIPTION
Fixes https://github.com/chef/train/issues/103 by adding an extra space after the path.

Here's a quick test I've done with the mount output from a few OSes:
```bash
$ cat ~/tmp/mount.out
# CentOS 6.6:
share on /mnt/share type vboxsf (uid=500,gid=500,rw)
# CentOS 7.2:
share on /mnt/share type vboxsf (rw,nodev,relatime)
# Ubuntu 14.04:
none on /mnt/share type tmpfs (rw,noexec,nosuid,nodev,size=5242880)
# OSX 10.11.4:
map auto_share on /mnt/share (autofs, automounted, nobrowse)
# Solaris 10(SunOS unknown 5.10):
/mnt/share on share read/write/setuid/devices/rstchown/xattr/dev=4cc0003 on Fri Sep 26 11:04:29 2014
$ grep -- ' on /mnt ' ~/tmp/mount.out
$ grep -- ' on /mnt/share ' ~/tmp/mount.out
share on /mnt/share type vboxsf (uid=500,gid=500,rw)
share on /mnt/share type vboxsf (rw,nodev,relatime)
none on /mnt/share type tmpfs (rw,noexec,nosuid,nodev,size=5242880)
map auto_share on /mnt/share (autofs, automounted, nobrowse)
```

The extra space fixes the issue, but needs to be revisited for better matching based on operating system. For example, Solaris mounts are not matched