### PR TITLE
Custom sudo command

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -32,6 +32,7 @@ module Train::Extras
     option :sudo, default: false
     option :sudo_options, default: nil
     option :sudo_password, default: nil
+    option :sudo_command, default: nil
     option :user
 
     def initialize(backend, options)
@@ -41,6 +42,7 @@ module Train::Extras
       @sudo = options[:sudo]
       @sudo_options = options[:sudo_options]
       @sudo_password = options[:sudo_password]
+      @sudo_command = options[:sudo_command]
       @user = options[:user]
       @prefix = build_prefix
     end
@@ -83,11 +85,11 @@ module Train::Extras
       return '' unless @sudo
       return '' if @user == 'root'
 
-      res = 'sudo '
+      res = (@sudo_command || 'sudo') + ' '
 
       unless @sudo_password.nil?
         b64pw = Base64.strict_encode64(@sudo_password + "\n")
-        res = "echo #{b64pw} | base64 -d | sudo -S "
+        res = "echo #{b64pw} | base64 -d | #{res}-S "
       end
 
       res << @sudo_options.to_s + ' ' unless @sudo_options.nil?

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -26,7 +26,7 @@ execute 'test ssh connection' do
 end
 
 # prepare a few users
-%w{ nopasswd passwd nosudo reqtty }.each do |name|
+%w{ nopasswd passwd nosudo reqtty customcommand }.each do |name|
   user name do
     password '$1$7MCNTXPI$r./jqCEoVlLlByYKSL3sZ.'
     manage_home true
@@ -53,6 +53,12 @@ sudo 'reqtty' do
   defaults ['requiretty']
 end
 
+sudo 'customcommand' do
+  user 'customcommand'
+  nopasswd true
+  defaults ['!requiretty']
+end
+
 # execute tests
 execute 'bundle install' do
   command '/opt/chef/embedded/bin/bundle install --without integration tools'
@@ -69,7 +75,7 @@ execute 'run ssh tests' do
   cwd '/tmp/kitchen/data'
 end
 
-%w{passwd nopasswd reqtty}.each do |name|
+%w{passwd nopasswd reqtty customcommand}.each do |name|
   execute "run local sudo tests as #{name}" do
     command "/opt/chef/embedded/bin/ruby -I lib test/integration/sudo/#{name}.rb"
     cwd '/tmp/kitchen/data'

--- a/test/integration/cookbooks/test/recipes/default.rb
+++ b/test/integration/cookbooks/test/recipes/default.rb
@@ -93,7 +93,7 @@ execute 'fix sudoers for reqtty' do
 end
 
 # if it's fixed, it should behave like user 'nopasswd'
-execute "run local sudo tests as reqtty, no longer requiring a tty" do
+execute 'run local sudo tests as reqtty, no longer requiring a tty' do
   command "/opt/chef/embedded/bin/ruby -I lib test/integration/sudo/nopasswd.rb"
   cwd '/tmp/kitchen/data'
   user 'reqtty'

--- a/test/integration/cookbooks/test/recipes/prep_files.rb
+++ b/test/integration/cookbooks/test/recipes/prep_files.rb
@@ -29,6 +29,13 @@ link '/tmp/symlink'do
   mode '0777'
 end
 
+link '/usr/bin/allyourbase' do
+  to '/usr/bin/sudo'
+  owner 'root'
+  group gid
+  mode '0777'
+end
+
 execute 'create pipe/fifo' do
   command 'mkfifo /tmp/pipe'
   not_if 'test -e /tmp/pipe'

--- a/test/integration/cookbooks/test/recipes/prep_files.rb
+++ b/test/integration/cookbooks/test/recipes/prep_files.rb
@@ -22,7 +22,7 @@ directory '/tmp/folder' do
   group gid
 end
 
-link '/tmp/symlink'do
+link '/tmp/symlink' do
   to '/tmp/file'
   owner 'root'
   group gid

--- a/test/integration/sudo/customcommand.rb
+++ b/test/integration/sudo/customcommand.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+# author: Jeremy Miller
+
+require_relative 'run_as'
+
+describe 'run custom sudo command' do
+  it 'is running as non-root without sudo' do
+    run_as('whoami').stdout.wont_match /root/i
+  end
+
+  it 'is running nopasswd custom sudo command' do
+    run_as('whoami', { sudo: true, sudo_command: 'allyourbase' } )
+      .stdout.must_match /root/i
+  end
+end

--- a/test/integration/sudo/customcommand.rb
+++ b/test/integration/sudo/customcommand.rb
@@ -5,11 +5,11 @@ require_relative 'run_as'
 
 describe 'run custom sudo command' do
   it 'is running as non-root without sudo' do
-    run_as('whoami').stdout.wont_match /root/i
+    run_as('whoami').stdout.wont_match(/root/i)
   end
 
   it 'is running nopasswd custom sudo command' do
-    run_as('whoami', { sudo: true, sudo_command: 'allyourbase' } )
-      .stdout.must_match /root/i
+    run_as('whoami', { sudo: true, sudo_command: 'allyourbase' })
+      .stdout.must_match(/root/i)
   end
 end

--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -38,6 +38,27 @@ describe 'linux command' do
     bpw = Base64.strict_encode64(pw + "\n")
     lc.run(cmd).must_equal "echo #{bpw} | base64 -d | sudo -S #{cmd}"
   end
+
+  it 'wraps commands in sudo_command instead of sudo' do
+    sudo_command = rand.to_s
+    lc = cls.new(backend, { sudo: true, sudo_command: sudo_command })
+    lc.run(cmd).must_equal "#{sudo_command} #{cmd}"
+  end
+
+  it 'wraps commands in sudo_command with all options' do
+    opts = rand.to_s
+    sudo_command = rand.to_s
+    lc = cls.new(backend, { sudo: true, sudo_command: sudo_command, sudo_options: opts })
+    lc.run(cmd).must_equal "#{sudo_command} #{opts} #{cmd}"
+  end
+
+  it 'runs commands in sudo_command with password' do
+    pw = rand.to_s
+    sudo_command = rand.to_s
+    lc = cls.new(backend, { sudo: true, sudo_command: sudo_command, sudo_password: pw })
+    bpw = Base64.strict_encode64(pw + "\n")
+    lc.run(cmd).must_equal "echo #{bpw} | base64 -d | #{sudo_command} -S #{cmd}"
+  end
 end
 
 describe 'powershell command' do


### PR DESCRIPTION
This gives train the ability to execute a custom sudo command.
Customers whom utilize authorization software like Centrify will frequently employ an alternative custom command to 'sudo'. 

Default remains 'sudo' if `:sudo_command` option is not specified.