### PR TITLE
provide uri-formatted information on all connections

### DIFF
--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -92,6 +92,14 @@ class Train::Transports::Docker
       raise
     end
 
+    def uri
+      if @container.nil?
+        "docker://#{@id}"
+      else
+        "docker://#{@container.id}"
+      end
+    end
+
     class OS < OSCommon
       def initialize(backend)
         # hardcoded to unix/linux for now, until other operating systems

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -47,6 +47,10 @@ module Train::Transports
       def login_command
         nil # none, open your shell
       end
+
+      def uri
+        'local://'
+      end
     end
   end
 end

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -70,6 +70,10 @@ class Train::Transports::Mock
       @commands = {}
     end
 
+    def uri
+      'mock://'
+    end
+
     def mock_os(value)
       @os = OS.new(self, value)
     end

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -151,6 +151,10 @@ class Train::Transports::SSH
       execute(PING_COMMAND.dup)
     end
 
+    def uri
+      "ssh://#{@username}@#{@hostname}:#{@port}"
+    end
+
     private
 
     PING_COMMAND = "echo '[SSH] Established'".freeze

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -27,7 +27,7 @@ class Train::Transports::WinRM
   # host such as executing commands, transferring files, etc.
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
-  class Connection < BaseConnection
+  class Connection < BaseConnection # rubocop:disable Metrics/ClassLength
     def initialize(options)
       super(options)
       @endpoint               = @options.delete(:endpoint)
@@ -42,7 +42,6 @@ class Train::Transports::WinRM
     # (see Base::Connection#close)
     def close
       return if @session.nil?
-
       session.close
     ensure
       @session = nil
@@ -97,6 +96,10 @@ class Train::Transports::WinRM
         retry_delay: delay,
       )
       execute(PING_COMMAND.dup)
+    end
+
+    def uri
+      "winrm://#{options[:user]}@#{@endpoint}:#{@rdp_port}"
     end
 
     private

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -32,6 +32,10 @@ describe 'local transport' do
     connection.must_be_kind_of Train::Transports::Local::Connection
   end
 
+  it 'provides a uri' do
+    connection.uri.must_equal "local://"
+  end
+
   it 'doesnt wait to be read' do
     connection.wait_until_ready.must_be_nil
   end

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -15,6 +15,10 @@ describe 'mock transport' do
     connection.wont_be_nil
   end
 
+  it 'provides a uri' do
+    connection.uri.must_equal 'mock://'
+  end
+
   describe 'when running a mocked command' do
     let(:mock_cmd) {  }
 

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -52,6 +52,10 @@ describe 'ssh transport' do
       connection.must_be_kind_of Train::Transports::SSH::Connection
     end
 
+    it 'provides a uri' do
+      connection.uri.must_equal "ssh://root@#{conf[:host]}:22"
+    end
+
     it 'must respond to wait_until_ready' do
       connection.must_respond_to :wait_until_ready
     end


### PR DESCRIPTION
Since Train provides `Train.target_config( ... )` which resolves target URIs to their transports, this PR provides the a mechanism to reverse the direction and go from `Connection` to URI.