### PR TITLE
adding support for vmware's esx server

### DIFF
--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -59,6 +59,9 @@ module Train::Extras
       'hpux' => %w{
         hpux
       },
+      'esx' => %w{
+        esx
+      },
     }
 
     OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware} + OS['redhat'] + OS['debian'] + OS['suse']
@@ -109,6 +112,7 @@ module Train::Extras
 
       return detect_windows if pf == 'windows'
       return detect_darwin if pf == 'darwin'
+      return detect_esx if pf == 'esx'
 
       if %w{freebsd netbsd openbsd aix solaris2 hpux}.include?(pf)
         return detect_via_uname

--- a/lib/train/extras/os_detect_esx.rb
+++ b/lib/train/extras/os_detect_esx.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+#
+# This is heavily based on:
+#
+#   OHAI https://github.com/chef/ohai
+#   by Adam Jacob, Chef Software Inc
+#
+
+module Train::Extras
+  module DetectEsx
+    def detect_esx
+      @platform[:family] = 'esx'
+      @platform[:name] = uname_s.lines[0].chomp
+      @platform[:release] = uname_r.lines[0].chomp
+      true
+    end
+  end
+end

--- a/test/unit/extras/os_common_test.rb
+++ b/test/unit/extras/os_common_test.rb
@@ -259,11 +259,19 @@ describe 'os common plugin' do
   end
 
   describe 'with platform set to hpux' do
-  let(:os) { mock_platform('hpux') }
-  it { os.solaris?.must_equal(false) }
-  it { os.linux?.must_equal(false) }
-  it { os.unix?.must_equal(true) }
-  it { os.hpux?.must_equal(true) }
-end
+    let(:os) { mock_platform('hpux') }
+    it { os.solaris?.must_equal(false) }
+    it { os.linux?.must_equal(false) }
+    it { os.unix?.must_equal(true) }
+    it { os.hpux?.must_equal(true) }
+  end
+
+  describe 'with platform set to esx' do
+    let(:os) { mock_platform('esx') }
+    it { os.solaris?.must_equal(false) }
+    it { os.linux?.must_equal(false) }
+    it { os.unix?.must_equal(false) }
+    it { os.esx?.must_equal(true) }
+  end
 
 end


### PR DESCRIPTION
added support for detecting esxi server. NO os_release or lsb_release file present. So only option is to go with uname. Doesn't come under linux or unix kernel. They have their own vmware proprietary kernel called VMKernel. 