### PR TITLE
json in and out for base connection

### DIFF
--- a/lib/train/extras/file_common.rb
+++ b/lib/train/extras/file_common.rb
@@ -9,10 +9,12 @@ module Train::Extras
   class FileCommon # rubocop:disable Metrics/ClassLength
     # interface methods: these fields should be implemented by every
     # backend File
-    %w{
+    DATA_FIELDS = %w{
       exist? mode owner group uid gid content mtime size selinux_label path
       product_version file_version
-    }.each do |m|
+    }.freeze
+
+    DATA_FIELDS.each do |m|
       define_method m.to_sym do
         fail NotImplementedError, "File must implement the #{m}() method."
       end

--- a/lib/train/extras/file_common.rb
+++ b/lib/train/extras/file_common.rb
@@ -26,6 +26,14 @@ module Train::Extras
       @follow_symlink = follow_symlink
     end
 
+    def to_json
+      res = Hash[DATA_FIELDS.map { |x| [x, method(x).call] }]
+      # additional fields provided as input
+      res['type'] = type
+      res['follow_symlink'] = @follow_symlink
+      res
+    end
+
     def type
       :unknown
     end

--- a/lib/train/extras/file_common.rb
+++ b/lib/train/extras/file_common.rb
@@ -60,27 +60,27 @@ module Train::Extras
     # Additional methods for convenience
 
     def file?
-      type == :file
+      type.to_s == 'file'
     end
 
     def block_device?
-      type == :block_device
+      type.to_s == 'block_device'
     end
 
     def character_device?
-      type == :character_device
+      type.to_s == 'character_device'
     end
 
     def socket?
-      type == :socket
+      type.to_s == 'socket'
     end
 
     def directory?
-      type == :directory
+      type.to_s == 'directory'
     end
 
     def symlink?
-      source.type == :symlink
+      source.type.to_s == 'symlink'
     end
 
     def source_path

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -36,6 +36,19 @@ class Train::Plugins::Transport
       # this method may be left unimplemented if that is applicable
     end
 
+    def to_json
+      {
+        'files' => Hash[@files.map { |x, y| [x, y.to_json] }],
+      }
+    end
+
+    def load_json(j)
+      require 'train/transports/mock'
+      j['files'].each do |path, jf|
+        @files[path] = Train::Transports::Mock::Connection::File.from_json(jf)
+      end
+    end
+
     # Execute a command using this connection.
     #
     # @param command [String] command string to execute

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -18,6 +18,9 @@ class Train::Plugins::Transport
   class BaseConnection
     include Train::Extras
 
+    # Provide access to the files cache.
+    attr_reader :files
+
     # Create a new Connection instance.
     #
     # @param options [Hash] connection options
@@ -25,6 +28,7 @@ class Train::Plugins::Transport
     def initialize(options = nil)
       @options = options || {}
       @logger = @options.delete(:logger) || Logger.new(STDOUT)
+      @files = {}
     end
 
     # Closes the session connection, if it is still active.

--- a/lib/train/transports/docker.rb
+++ b/lib/train/transports/docker.rb
@@ -60,7 +60,6 @@ class Train::Transports::Docker
       @id = options[:host]
       @container = ::Docker::Container.get(@id) ||
                    fail("Can't find Docker container #{@id}")
-      @files = {}
       @cmd_wrapper = nil
       @cmd_wrapper = CommandWrapper.load(self, @options)
       self

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -22,7 +22,6 @@ module Train::Transports
     class Connection < BaseConnection
       def initialize(options)
         super(options)
-        @files = {}
         @cmd_wrapper = nil
         @cmd_wrapper = CommandWrapper.load(self, options)
       end

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -143,6 +143,11 @@ class Train::Transports::Mock::Connection
 
     Train::Extras::FileCommon::DATA_FIELDS.each do |m|
       attr_accessor m.tr('?', '').to_sym
+      next unless m.include?('?')
+
+      define_method m.to_sym do
+        method(m.tr('?', '').to_sym).call
+      end
     end
     attr_accessor :type
 

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -129,10 +129,7 @@ end
 
 class Train::Transports::Mock::Connection
   class File < FileCommon
-    %w{
-      exist? mode owner group link_path content mtime size
-      selinux_label product_version file_version path type
-    }.each do |m|
+    Train::Extras::FileCommon::DATA_FIELDS.each do |m|
       attr_accessor m.tr('?', '').to_sym
     end
 

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -129,9 +129,22 @@ end
 
 class Train::Transports::Mock::Connection
   class File < FileCommon
+    def self.from_json(json)
+      res = new(json['backend'],
+                json['path'],
+                json['follow_symlink'])
+      res.type = json['type']
+      Train::Extras::FileCommon::DATA_FIELDS.each do |f|
+        m = (f.tr('?', '') + '=').to_sym
+        res.method(m).call(json[f])
+      end
+      res
+    end
+
     Train::Extras::FileCommon::DATA_FIELDS.each do |m|
       attr_accessor m.tr('?', '').to_sym
     end
+    attr_accessor :type
 
     def initialize(backend, path, follow_symlink = true)
       super(backend, path, follow_symlink)

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -65,7 +65,6 @@ class Train::Transports::Mock
 
     def initialize(conf = nil)
       @conf = conf || {}
-      @files = {}
       @os = OS.new(self, family: 'unknown')
       @commands = {}
     end

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -38,7 +38,6 @@ class Train::Transports::SSH
       @connection_retries     = @options.delete(:connection_retries)
       @connection_retry_sleep = @options.delete(:connection_retry_sleep)
       @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
-      @files                  = {}
       @session                = nil
       @transport_options      = @options.delete(:transport_options)
       @cmd_wrapper            = nil

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -36,7 +36,6 @@ class Train::Transports::WinRM
       @connection_retries     = @options.delete(:connection_retries)
       @connection_retry_sleep = @options.delete(:connection_retry_sleep)
       @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
-      @files                  = {}
     end
 
     # (see Base::Connection#close)

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -27,7 +27,7 @@ class Train::Transports::WinRM
   # host such as executing commands, transferring files, etc.
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
-  class Connection < BaseConnection # rubocop:disable Metrics/ClassLength
+  class Connection < BaseConnection
     def initialize(options)
       super(options)
       @endpoint               = @options.delete(:endpoint)

--- a/test/integration/tests/path_file_test.rb
+++ b/test/integration/tests/path_file_test.rb
@@ -75,5 +75,11 @@ describe 'file interface' do
     it 'has no file_version' do
       file.file_version.must_equal(nil)
     end
+
+    it 'provides a json representation' do
+      j = file.to_json
+      j.must_be_kind_of Hash
+      j['type'].must_equal :file
+    end
   end
 end

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -84,8 +84,15 @@ describe 'mock transport' do
   end
 
   describe 'when accessing a mocked file' do
-    it 'gets results for content' do
+    JSON = Train.create('local').connection.file(__FILE__).to_json
+    RES = Train::Transports::Mock::Connection::File.from_json(JSON)
 
+    # tests if all fields between the local json and resulting mock file
+    # are equal
+    %w{ content mode owner group }.each do |f|
+      it "can be initialized from json (field #{f})" do
+        RES.method(f).call.must_equal JSON[f]
+      end
     end
   end
 end


### PR DESCRIPTION
Provide the base connection with dict in and out methods: `to_json` and `load_json`

Also:
* Fixes a few methods missing in mock file class, after we had changed them in FileCommon; all accessors that carry data are now exposed (e.g. `link_path` had been replaced in `FileCommon`)
* Moves `@files` initialization to `FileCommon`