### PR TITLE
bugfix: add mock backend initialization

### DIFF
--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -64,7 +64,7 @@ class Train::Transports::Mock
     attr_reader :os
 
     def initialize(conf = nil)
-      @conf = conf || {}
+      super(conf)
       @os = OS.new(self, family: 'unknown')
       @commands = {}
     end
@@ -82,7 +82,7 @@ class Train::Transports::Mock
     end
 
     def command_not_found(cmd)
-      if @conf[:verbose]
+      if @options[:verbose]
         STDERR.puts('Command not mocked:')
         STDERR.puts('    '+cmd.to_s.split("\n").join("\n    "))
         STDERR.puts('    SHA: ' + Digest::SHA256.hexdigest(cmd.to_s))
@@ -97,7 +97,7 @@ class Train::Transports::Mock
     end
 
     def file_not_found(path)
-      STDERR.puts('File not mocked: '+path.to_s) if @conf[:verbose]
+      STDERR.puts('File not mocked: '+path.to_s) if @options[:verbose]
       File.new(self, path)
     end
 

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -84,11 +84,18 @@ describe 'mock transport' do
   end
 
   describe 'when accessing a mocked file' do
-    JSON = Train.create('local').connection.file(__FILE__).to_json
-    RES = Train::Transports::Mock::Connection::File.from_json(JSON)
+    it 'handles a non-existing file' do
+      x = rand.to_s
+      f = connection.file(x)
+      f.must_be_kind_of Train::Transports::Mock::Connection::File
+      f.exist?.must_equal false
+      f.path.must_equal x
+    end
 
     # tests if all fields between the local json and resulting mock file
     # are equal
+    JSON = Train.create('local').connection.file(__FILE__).to_json
+    RES = Train::Transports::Mock::Connection::File.from_json(JSON)
     %w{ content mode owner group }.each do |f|
       it "can be initialized from json (field #{f})" do
         RES.method(f).call.must_equal JSON[f]


### PR DESCRIPTION
This was missing and led to `@files` being `nil`. Fixed by calling super and optimized by using the base class' `@options` instead of creating a custom variable.