### PR TITLE
do not log password in ssh connection output

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -216,7 +216,9 @@ class Train::Transports::SSH
     #
     # @api private
     def to_s
-      "#{@username}@#{@hostname}<#{@options.inspect}>"
+      options_to_print = @options.clone
+      options_to_print[:password] = "<hidden>" if options_to_print.has_key?(:password)
+      "#{@username}@#{@hostname}<#{options_to_print.inspect}>"
     end
 
     class OS < OSCommon

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -217,7 +217,7 @@ class Train::Transports::SSH
     # @api private
     def to_s
       options_to_print = @options.clone
-      options_to_print[:password] = "<hidden>" if options_to_print.has_key?(:password)
+      options_to_print[:password] = '<hidden>' if options_to_print.key?(:password)
       "#{@username}@#{@hostname}<#{options_to_print.inspect}>"
     end
 

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -82,6 +82,15 @@ describe 'ssh transport' do
     end
   end
 
+  describe 'converting connection to string for logging' do
+   it "masks passwords" do
+      assert_output(/.*:password=>"<hidden>".*/) do
+        connection = cls.new(conf).connection
+        puts "#{connection}"
+      end
+    end
+  end
+
   describe 'failed configuration' do
     it 'works with a minimum valid config' do
       cls.new(conf).connection


### PR DESCRIPTION
This addresses an immediate need for delivery CLIP, but a better longer-term approach may be to make something like: 

```
class ConnectionOptions < Hash 
  def to_s
    # find any  key => .*password.* with value type String  here and obscure them. 
  end
end
```
I didn't take that for this change because it'd be a mid-sized refactor. 

ping  @arlimus @srenatus  
