### PR TITLE
Use winrm v2 implementation

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -3,7 +3,6 @@
 # author: Christoph Hartmann
 
 require 'base64'
-require 'winrm'
 require 'train/errors'
 
 module Train::Extras
@@ -114,13 +113,20 @@ module Train::Extras
       # especially in local mode, we cannot be sure that we get a Powershell
       # we may just get a `cmd`.
       # TODO: we may want to opt for powershell.exe -command instead of `encodeCommand`
-      "powershell -encodedCommand #{WinRM::PowershellScript.new(safe_script(script)).encoded}"
+      "powershell -encodedCommand #{encoded(safe_script(script))}"
     end
 
-    # reused from https://github.com/WinRb/WinRM/blob/master/lib/winrm/command_executor.rb
     # suppress the progress stream from leaking to stderr
     def safe_script(script)
       "$ProgressPreference='SilentlyContinue';" + script
+    end
+
+    # Encodes the script so that it can be passed to the PowerShell
+    # --EncodedCommand argument.
+    # @return [String] The UTF-16LE base64 encoded script
+    def encoded(script)
+      encoded_script = safe_script(script).encode('UTF-16LE', 'UTF-8')
+      Base64.strict_encode64(encoded_script)
     end
 
     def to_s

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -89,7 +89,7 @@ module Train::Transports
       opts[:endpoint] = "#{scheme}://#{opts[:host]}:#{port}/#{path}"
     end
 
-    WINRM_FS_SPEC_VERSION = '~> 0.3'.freeze
+    WINRM_FS_SPEC_VERSION = '~> 1.0'.freeze
 
     # Builds the hash of options needed by the Connection object on
     # construction.
@@ -100,12 +100,12 @@ module Train::Transports
     def connection_options(opts)
       {
         logger:                   logger,
-        winrm_transport:          :negotiate,
+        transport:                :negotiate,
         disable_sspi:             false,
         basic_auth_only:          false,
         endpoint:                 opts[:endpoint],
         user:                     opts[:user],
-        pass:                     opts[:password],
+        password:                 opts[:password],
         rdp_port:                 opts[:rdp_port],
         connection_retries:       opts[:connection_retries],
         connection_retry_sleep:   opts[:connection_retry_sleep],

--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -60,19 +60,3 @@ describe 'linux command' do
     lc.run(cmd).must_equal "echo #{bpw} | base64 --decode | #{sudo_command} -S #{cmd}"
   end
 end
-
-describe 'powershell command' do
-  let(:cls) { Train::Extras::PowerShellCommand }
-  let(:cmd) { rand.to_s }
-  let(:backend) {
-    backend = Train::Transports::Mock.new.connection
-    backend.mock_os({ family: 'windows' })
-    backend
-  }
-
-  it 'wraps commands in powershell' do
-    lc = cls.new(backend, {})
-    tmp =
-    lc.run(cmd).must_equal "powershell -encodedCommand #{WinRM::PowershellScript.new('$ProgressPreference=\'SilentlyContinue\';' + cmd).encoded}"
-  end
-end

--- a/train.gemspec
+++ b/train.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   # 1.9 support is no longer needed here or for Inspec
   spec.add_dependency 'net-ssh', '>= 2.9', '< 4.0'
   spec.add_dependency 'net-scp', '~> 1.2'
-  spec.add_dependency 'winrm', '~> 1.6'
-  spec.add_dependency 'winrm-fs', '~> 0.3'
+  spec.add_dependency 'winrm', '~> 2.0'
+  spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'
 
   spec.add_development_dependency 'mocha', '~> 1.1'


### PR DESCRIPTION
Test-Kitchen using winrm v2 has just been released. I'll be removing the WIP from kitchen-inspec momentarily as well.