### PR TITLE
Test ruby 2.1 instead of 1.9.3 and only launch one test group per travis/appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,13 @@ before_install:
   - gem install bundler
   - gem --version
 
+branches:
+  only:
+  - master
+
 matrix:
   include:
-  - rvm: 1.9.3
+  - rvm: 2.1
   - rvm: 2.0
   - rvm: 2.2
     script: bundle exec rake test test:docker config=test-travis-1.yaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
   bundler_url: https://rubygems.org/downloads/bundler-1.9.9.gem
 
   matrix:
-    - ruby_version: "193"
+    - ruby_version: "21"
       train_target: winrm://test_user@localhost:5985
 
     - ruby_version: "22"
@@ -22,6 +22,10 @@ environment:
 
 clone_folder: c:\projects\train
 clone_depth: 1
+
+branches:
+  only:
+    - master
 
 cache:
   - vendor/bundle -> appveyor.yml


### PR DESCRIPTION
Ruby 2.0 has been unsupported for some time now. Chef/Chef-DK ships with 2.1 and may soon bump to 2.2. This also gets rid of double travis/appveyor runs in PRs.