### PR TITLE
Bring train platform data more in line with ohai's platform data

### DIFF
--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -62,7 +62,7 @@ module Train::Extras
       },
     }
 
-    OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware fedora} + OS['redhat'] + OS['debian'] + OS['suse']
+    OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware fedora amazon} + OS['redhat'] + OS['debian'] + OS['suse']
 
     OS['unix'] = %w{unix aix hpux} + OS['linux'] + OS['solaris'] + OS['bsd']
 

--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -38,15 +38,10 @@ module Train::Extras
     end
 
     OS = { # rubocop:disable Style/MutableConstant
-      'redhat' => %w{
-        redhat oracle centos fedora amazon scientific xenserver wrlinux
-      },
-      'debian' => %w{
-        debian ubuntu linuxmint raspbian
-      },
-      'suse' => %w{
-        suse opensuse
-      },
+      'redhat' => REDHAT_FAMILY,
+      'debian' => DEBIAN_FAMILY,
+      'suse' => SUSE_FAMILY,
+      'fedora' => %w{fedora},
       'bsd' => %w{
         freebsd netbsd openbsd darwin
       },
@@ -67,7 +62,7 @@ module Train::Extras
       },
     }
 
-    OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware} + OS['redhat'] + OS['debian'] + OS['suse']
+    OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware fedora} + OS['redhat'] + OS['debian'] + OS['suse']
 
     OS['unix'] = %w{unix aix hpux} + OS['linux'] + OS['solaris'] + OS['bsd']
 

--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -22,6 +22,7 @@ module Train::Extras
     include Train::Extras::DetectWindows
     include Train::Extras::DetectEsx
 
+    attr_accessor :backend
     def initialize(backend, platform = nil)
       @backend = backend
       @platform = platform || {}

--- a/lib/train/extras/os_detect_darwin.rb
+++ b/lib/train/extras/os_detect_darwin.rb
@@ -7,9 +7,12 @@
 #   OHAI https://github.com/chef/ohai
 #   by Adam Jacob, Chef Software Inc
 #
+require 'train/extras/uname'
 
 module Train::Extras
   module DetectDarwin
+    include Train::Extras::Uname
+
     def detect_darwin
       cmd = @backend.run_command('/usr/bin/sw_vers')
       # TODO: print an error in this step of the detection,
@@ -17,9 +20,6 @@ module Train::Extras
       return false if cmd.exit_status != 0
       # TODO: ditto on error
       return false if cmd.stdout.empty?
-
-      uname_m = @backend.run_command("uname -m").stdout.chomp
-      return false if uname_m.empty?
 
       name = cmd.stdout[/^ProductName:\s+(.+)$/, 1]
       # TODO: ditto on error
@@ -29,8 +29,12 @@ module Train::Extras
       @platform[:build] = cmd.stdout[/^BuildVersion:\s+(.+)$/, 1]
       # TODO: keep for now due to backwards compatibility with serverspec
       @platform[:family] = 'darwin'
-      @platform[:arch] = uname_m
+      detect_darwin_arch
       true
+    end
+
+    def detect_darwin_arch
+      @platform[:arch] = uname_m
     end
   end
 end

--- a/lib/train/extras/os_detect_darwin.rb
+++ b/lib/train/extras/os_detect_darwin.rb
@@ -18,6 +18,9 @@ module Train::Extras
       # TODO: ditto on error
       return false if cmd.stdout.empty?
 
+      uname_m = @backend.run_command("uname -m").stdout.chomp
+      return false if uname_m.empty?
+
       name = cmd.stdout[/^ProductName:\s+(.+)$/, 1]
       # TODO: ditto on error
       return false if name.nil?
@@ -26,6 +29,7 @@ module Train::Extras
       @platform[:build] = cmd.stdout[/^BuildVersion:\s+(.+)$/, 1]
       # TODO: keep for now due to backwards compatibility with serverspec
       @platform[:family] = 'darwin'
+      @platform[:arch] = uname_m
       true
     end
   end

--- a/lib/train/extras/os_detect_linux.rb
+++ b/lib/train/extras/os_detect_linux.rb
@@ -16,77 +16,92 @@ module Train::Extras
 
     def detect_linux_via_config # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       if !(raw = get_config('oracle-release')).nil?
-        @platform[:family] = 'oracle'
+        @platform[:name] = 'oracle'
         @platform[:release] = redhatish_version(raw)
       elsif !(raw = get_config('/etc/enterprise-release')).nil?
-        @platform[:family] = 'oracle'
+        @platform[:name] = 'oracle'
         @platform[:release] = redhatish_version(raw)
       elsif !(raw = get_config('/etc/debian_version')).nil?
         case lsb[:id]
         when /ubuntu/i
-          @platform[:family] = 'ubuntu'
+          @platform[:name] = 'ubuntu'
           @platform[:release] = lsb[:release]
         when /linuxmint/i
-          @platform[:family] = 'linuxmint'
+          @platform[:name] = 'linuxmint'
           @platform[:release] = lsb[:release]
         else
-          @platform[:family] = unix_file?('/usr/bin/raspi-config') ? 'raspbian' : 'debian'
+          @platform[:name] = unix_file?('/usr/bin/raspi-config') ? 'raspbian' : 'debian'
           @platform[:release] = raw.chomp
         end
       elsif !(raw = get_config('/etc/parallels-release')).nil?
-        @platform[:family] = redhatish_platform(raw)
+        @platform[:name] = redhatish_platform(raw)
         @platform[:release] = raw[/(\d\.\d\.\d)/, 1]
       elsif !(raw = get_config('/etc/redhat-release')).nil?
         # TODO: Cisco
         # TODO: fully investigate os-release and integrate it;
         # here we just use it for centos
-        if !(osrel = get_config('/etc/os-release')).nil? && osrel =~ /centos/i
-          @platform[:family] = 'centos'
-        else
-          @platform[:family] = redhatish_platform(raw)
-        end
+        @platform[:name] = if !(osrel = get_config('/etc/os-release')).nil? && osrel =~ /centos/i
+                             'centos'
+                           else
+                             redhatish_platform(raw)
+                           end
+
         @platform[:release] = redhatish_version(raw)
       elsif !(raw = get_config('/etc/system-release')).nil?
         # Amazon Linux
-        @platform[:family] = redhatish_platform(raw)
+        @platform[:name] = redhatish_platform(raw)
         @platform[:release] = redhatish_version(raw)
       elsif !(suse = get_config('/etc/SuSE-release')).nil?
         version = suse.scan(/VERSION = (\d+)\nPATCHLEVEL = (\d+)/).flatten.join('.')
         version = suse[/VERSION = ([\d\.]{2,})/, 1] if version == ''
         @platform[:release] = version
-        @platform[:family] = 'suse'
-        @platform[:family] = 'opensuse' if suse =~ /^openSUSE/
+        @platform[:name] =  if suse =~ /^openSUSE/
+                              'opensuse'
+                            else
+                              'suse'
+                            end
       elsif !(raw = get_config('/etc/arch-release')).nil?
-        @platform[:family] = 'arch'
+        @platform[:name] = 'arch'
         # Because this is a rolling release distribution,
         # use the kernel release, ex. 4.1.6-1-ARCH
         @platform[:release] = uname_r
       elsif !(raw = get_config('/etc/slackware-version')).nil?
-        @platform[:family] = 'slackware'
+        @platform[:name] = 'slackware'
         @platform[:release] = raw.scan(/(\d+|\.+)/).join
       elsif !(raw = get_config('/etc/exherbo-release')).nil?
-        @platform[:family] = 'exherbo'
+        @platform[:name] = 'exherbo'
         # Because this is a rolling release distribution,
         # use the kernel release, ex. 4.1.6
         @platform[:release] = uname_r
       elsif !(raw = get_config('/etc/gentoo-release')).nil?
-        @platform[:family] = 'gentoo'
+        @platform[:name] = 'gentoo'
         @platform[:release] = raw.scan(/(\d+|\.+)/).join
       elsif !(raw = get_config('/etc/alpine-release')).nil?
-        @platform[:family] = 'alpine'
+        @platform[:name] = 'alpine'
         @platform[:release] = raw.strip
       elsif !(raw = get_config('/etc/coreos/update.conf')).nil?
-        @platform[:family] = 'coreos'
+        @platform[:name] = 'coreos'
         meta = lsb_config(raw)
         @platform[:release] = meta[:release]
       elsif !(os_info = fetch_os_release).nil?
         if os_info['ID_LIKE'] =~ /wrlinux/
-          @platform[:family]  = 'wrlinux'
+          @platform[:name]  = 'wrlinux'
           @platform[:release] = os_info['VERSION']
         end
       end
 
+      @platform[:family] = family_for_platform
+
       !@platform[:family].nil? && !@platform[:release].nil?
+    end
+
+    def family_for_platform
+      case @platform[:name]
+      when 'centos'
+        'redhat'
+      else
+        @platform[:name] || @platform[:family]
+      end
     end
 
     def uname_s

--- a/lib/train/extras/os_detect_linux.rb
+++ b/lib/train/extras/os_detect_linux.rb
@@ -105,15 +105,19 @@ module Train::Extras
     end
 
     def uname_s
-      @uname_s ||= @backend.run_command('uname -s').stdout
+      @uname_s ||= backend.run_command('uname -s').stdout
     end
 
     def uname_r
       @uname_r ||= (
-        res = @backend.run_command('uname -r').stdout
+        res = backend.run_command('uname -r').stdout
         res.strip! unless res.nil?
         res
       )
+    end
+
+    def uname_m
+      @uname_m ||= backend.run_command('uname -m').stdout.chomp
     end
 
     def redhatish_platform(conf)
@@ -126,10 +130,20 @@ module Train::Extras
       conf[/release ([\d\.]+)/, 1]
     end
 
+    def detect_linux_architecture
+      if uname_m.nil? || uname_m.empty?
+        false
+      else
+        @platform[:arch] = uname_m
+        true
+      end
+    end
+
     def detect_linux
       # TODO: print an error in this step of the detection
       return false if uname_s.nil? || uname_s.empty?
       return false if uname_r.nil? || uname_r.empty?
+      return false if !detect_linux_architecture
 
       return true if detect_linux_via_config
       return true if detect_linux_via_lsb

--- a/lib/train/extras/uname.rb
+++ b/lib/train/extras/uname.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+# author: Dominik Richter
+# author: Christoph Hartmann
+#
+# This is heavily based on:
+#
+#   OHAI https://github.com/chef/ohai
+#   by Adam Jacob, Chef Software Inc
+#
+module Train::Extras
+  module Uname
+    def uname_s
+      @uname_s ||= backend.run_command('uname -s').stdout
+    end
+
+    def uname_r
+      @uname_r ||= begin
+                     res = backend.run_command('uname -r').stdout
+                     res.strip! unless res.nil?
+                     res
+                   end
+    end
+
+    def uname_m
+      @uname_m ||= backend.run_command('uname -m').stdout.chomp
+    end
+  end
+end

--- a/test/unit/extras/os_common_test.rb
+++ b/test/unit/extras/os_common_test.rb
@@ -65,6 +65,16 @@ describe 'os common plugin' do
     it { os.unix?.must_equal(true) }
   end
 
+  describe 'with platform set to amazon' do
+    let(:os) { mock_platform('amazon') }
+    it { os.fedora?.must_equal(false) }
+    it { os.redhat?.must_equal(false) }
+    it { os.debian?.must_equal(false) }
+    it { os.suse?.must_equal(false) }
+    it { os.linux?.must_equal(true) }
+    it { os.unix?.must_equal(true) }
+  end
+
   describe 'with platform set to debian' do
     let(:os) { mock_platform('debian') }
     it { os.redhat?.must_equal(false) }

--- a/test/unit/extras/os_common_test.rb
+++ b/test/unit/extras/os_common_test.rb
@@ -57,7 +57,8 @@ describe 'os common plugin' do
 
   describe 'with platform set to fedora' do
     let(:os) { mock_platform('fedora') }
-    it { os.redhat?.must_equal(true) }
+    it { os.fedora?.must_equal(true) }
+    it { os.redhat?.must_equal(false) }
     it { os.debian?.must_equal(false) }
     it { os.suse?.must_equal(false) }
     it { os.linux?.must_equal(true) }

--- a/test/unit/extras/os_detect_linux_test.rb
+++ b/test/unit/extras/os_detect_linux_test.rb
@@ -32,6 +32,19 @@ describe 'os_detect_linux' do
       end
     end
 
+    describe "/etc/redhat-release" do
+      describe "and /etc/os-release" do
+        it "sets the correct family, name, and release on centos" do
+          detector.stubs(:get_config).with("/etc/redhat-release").returns("CentOS Linux release 7.2.1511 (Core) \n")
+          detector.stubs(:get_config).with("/etc/os-release").returns("NAME=\"CentOS Linux\"\nVERSION=\"7 (Core)\"\nID=\"centos\"\nID_LIKE=\"rhel fedora\"\n")
+          detector.detect_linux_via_config.must_equal(true)
+          detector.platform[:name].must_equal('centos')
+          detector.platform[:family].must_equal('redhat')
+          detector.platform[:release].must_equal('redhat-version')
+        end
+      end
+    end
+
     describe '/etc/debian_version' do
 
       before { detector.stubs(:get_config).with('/etc/debian_version').returns('deb-version') }

--- a/test/unit/extras/os_detect_linux_test.rb
+++ b/test/unit/extras/os_detect_linux_test.rb
@@ -14,13 +14,13 @@ end
 describe 'os_detect_linux' do
   let(:detector) { OsDetectLinuxTester.new }
 
-  describe '#detect_linux_architecture' do
+  describe '#detect_linux_arch' do
     it "sets the arch using uname" do
       be = mock("Backend")
       detector.stubs(:backend).returns(be)
       be.stubs(:run_command).with("uname -m").returns(mock("Output", stdout: "x86_64\n"))
-      detector.detect_linux_architecture.must_equal(true)
-      detector.platform[:arch].must_equal("x84_64")
+      detector.detect_linux_arch
+      detector.platform[:arch].must_equal("x86_64")
     end
   end
 
@@ -37,7 +37,8 @@ describe 'os_detect_linux' do
         detector.stubs(:get_config).with('/etc/enterprise-release').returns('data')
 
         detector.detect_linux_via_config.must_equal(true)
-        detector.platform[:family].must_equal('oracle')
+        detector.platform[:name].must_equal('oracle')
+        detector.platform[:family].must_equal('redhat')
         detector.platform[:release].must_equal('redhat-version')
       end
     end
@@ -64,7 +65,8 @@ describe 'os_detect_linux' do
           detector.stubs(:lsb).returns({ id: 'ubuntu', release: 'ubuntu-release' })
 
           detector.detect_linux_via_config.must_equal(true)
-          detector.platform[:family].must_equal('ubuntu')
+          detector.platform[:name].must_equal('ubuntu')
+          detector.platform[:family].must_equal('debian')
           detector.platform[:release].must_equal('ubuntu-release')
         end
       end
@@ -74,7 +76,8 @@ describe 'os_detect_linux' do
           detector.stubs(:lsb).returns({ id: 'linuxmint', release: 'mint-release' })
 
           detector.detect_linux_via_config.must_equal(true)
-          detector.platform[:family].must_equal('linuxmint')
+          detector.platform[:name].must_equal('linuxmint')
+          detector.platform[:family].must_equal('debian')
           detector.platform[:release].must_equal('mint-release')
         end
       end
@@ -85,7 +88,8 @@ describe 'os_detect_linux' do
           detector.expects(:unix_file?).with('/usr/bin/raspi-config').returns(true)
 
           detector.detect_linux_via_config.must_equal(true)
-          detector.platform[:family].must_equal('raspbian')
+          detector.platform[:name].must_equal('raspbian')
+          detector.platform[:family].must_equal('debian')
           detector.platform[:release].must_equal('deb-version')
         end
       end
@@ -96,6 +100,7 @@ describe 'os_detect_linux' do
           detector.expects(:unix_file?).with('/usr/bin/raspi-config').returns(false)
 
           detector.detect_linux_via_config.must_equal(true)
+          detector.platform[:name].must_equal('debian')
           detector.platform[:family].must_equal('debian')
           detector.platform[:release].must_equal('deb-version')
         end
@@ -125,7 +130,8 @@ describe 'os_detect_linux' do
           detector.stubs(:fetch_os_release).returns(data)
 
           detector.detect_linux_via_config.must_equal(true)
-          detector.platform[:family].must_equal('wrlinux')
+          detector.platform[:name].must_equal('wrlinux')
+          detector.platform[:family].must_equal('redhat')
           detector.platform[:release].must_equal('cisco123')
         end
       end

--- a/test/unit/extras/os_detect_linux_test.rb
+++ b/test/unit/extras/os_detect_linux_test.rb
@@ -14,6 +14,16 @@ end
 describe 'os_detect_linux' do
   let(:detector) { OsDetectLinuxTester.new }
 
+  describe '#detect_linux_architecture' do
+    it "sets the arch using uname" do
+      be = mock("Backend")
+      detector.stubs(:backend).returns(be)
+      be.stubs(:run_command).with("uname -m").returns(mock("Output", stdout: "x86_64\n"))
+      detector.detect_linux_architecture.must_equal(true)
+      detector.platform[:arch].must_equal("x84_64")
+    end
+  end
+
   describe '#detect_linux_via_config' do
 
     before do


### PR DESCRIPTION
With this PR `family` refers to the distribuion family while `name` refers to the specific distribution. For example, the family attribute for ubuntu is `debian`. Further, architecture information is collected for Linux and OS X using `uname -m`.

This includes possibly breaking changes:

- The following platforms are now their own family and not listed as part of the `redhat` family: `amazon`, `fedora`.

- The following platforms are now part of the `redhat` family whereas before they were their own families: `centos oracle scientific enterpriseenterprise xenserver cloudlinux ibm_powerkvm nexus_centos wrlinux`

- The following platforms are now part of the `debian` family wheras before they were their own families: `ubuntu`, `linuxmint`, `raspbian`

- `opensuse` and `suse` are now part of a single `suse` family.