### PR TITLE
Rescue EPIPE on connect in ssh transport

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -166,7 +166,7 @@ class Train::Transports::SSH
 
     RESCUE_EXCEPTIONS_ON_ESTABLISH = [
       Errno::EACCES, Errno::EADDRINUSE, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-      Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
+      Errno::ECONNRESET, Errno::ENETUNREACH, Errno::EHOSTUNREACH, Errno::EPIPE,
       Net::SSH::Disconnect, Net::SSH::AuthenticationFailed, Net::SSH::ConnectionTimeout,
       Timeout::Error
     ].freeze


### PR DESCRIPTION
SSH will raise an Errno::EPIPE if the remote server closes the
connection unexpectedly. This can happen, for example, in cases where a
user has an improperly configured ProxyCommand for that host in
`~/.ssh/config`.

Adding EPIPE to the set of exceptions to rescue ensures that we raise
Train::Transports::SSHFailed which callers of train my already be
rescuing.