### PR TITLE
return owner for files on windows

### DIFF
--- a/lib/train/extras/file_windows.rb
+++ b/lib/train/extras/file_windows.rb
@@ -51,6 +51,13 @@ module Train::Extras
       nil
     end
 
+    def owner
+      owner = @backend.run_command(
+        "Get-Acl '#{@spath}' | select -expand Owner").stdout.strip
+      return if owner.empty?
+      owner
+    end
+
     def type
       if attributes.include?('Archive')
         return :file
@@ -61,7 +68,7 @@ module Train::Extras
     end
 
     %w{
-      mode owner group uid gid mtime size selinux_label
+      mode group uid gid mtime size selinux_label
     }.each do |field|
       define_method field.to_sym do
         nil


### PR DESCRIPTION
This PR implements the owner methods for file/directory on Windows platforms. Once this is done, you can read our the owner via InSpec:

```
  describe directory('C:/opscode/chef') do
    its('owner') { should cmp 'NT AUTHORITY\SYSTEM'}
  end
  describe directory('C:/opscode/chef') do
    it { should be_owned_by 'NT AUTHORITY\SYSTEM' }
  end
  describe directory('C:/notthere') do
    its('owner') { should eq nil}
  end
```