### PR TITLE
rescue docker erros during container shutdown

### DIFF
--- a/test/integration/docker_run.rb
+++ b/test/integration/docker_run.rb
@@ -136,6 +136,8 @@ class DockerRunner
     puts "--> killrm docker #{container.id}"
     container.kill
     container.delete(force: true)
+  rescue Exception => e
+    puts e.message
   end
 
   private


### PR DESCRIPTION
This PR catches potential errors in our integration tests during docker shutdown. We can ignore errors during shutdown time, since they are not train related.