### PR TITLE
use --decode on base64 command to maintain compatibility with Darwin.

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -89,7 +89,7 @@ module Train::Extras
 
       unless @sudo_password.nil?
         b64pw = Base64.strict_encode64(@sudo_password + "\n")
-        res = "echo #{b64pw} | base64 -d | #{res}-S "
+        res = "echo #{b64pw} | base64 --decode | #{res}-S "
       end
 
       res << @sudo_options.to_s + ' ' unless @sudo_options.nil?

--- a/test/unit/extras/command_wrapper_test.rb
+++ b/test/unit/extras/command_wrapper_test.rb
@@ -36,7 +36,7 @@ describe 'linux command' do
     pw = rand.to_s
     lc = cls.new(backend, { sudo: true, sudo_password: pw })
     bpw = Base64.strict_encode64(pw + "\n")
-    lc.run(cmd).must_equal "echo #{bpw} | base64 -d | sudo -S #{cmd}"
+    lc.run(cmd).must_equal "echo #{bpw} | base64 --decode | sudo -S #{cmd}"
   end
 
   it 'wraps commands in sudo_command instead of sudo' do
@@ -57,7 +57,7 @@ describe 'linux command' do
     sudo_command = rand.to_s
     lc = cls.new(backend, { sudo: true, sudo_command: sudo_command, sudo_password: pw })
     bpw = Base64.strict_encode64(pw + "\n")
-    lc.run(cmd).must_equal "echo #{bpw} | base64 -d | #{sudo_command} -S #{cmd}"
+    lc.run(cmd).must_equal "echo #{bpw} | base64 --decode | #{sudo_command} -S #{cmd}"
   end
 end
 


### PR DESCRIPTION
This is a fix for https://github.com/chef/train/issues/136. OSX was the only BSD I could find that was running an old enough version of base64 to have this issue. But this fix should catch any others.