### PR TITLE
Add the darwin platform family

### DIFF
--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -60,6 +60,9 @@ module Train::Extras
       'esx' => %w{
         esx
       },
+      'darwin' => %w{
+        darwin
+      },
     }
 
     OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware fedora amazon} + OS['redhat'] + OS['debian'] + OS['suse']

--- a/test/unit/extras/os_common_test.rb
+++ b/test/unit/extras/os_common_test.rb
@@ -286,4 +286,14 @@ describe 'os common plugin' do
     it { os.esx?.must_equal(true) }
   end
 
+  describe 'with platform set to darwin' do
+    let(:os) { mock_platform('darwin') }
+    it { os.solaris?.must_equal(false) }
+    it { os.linux?.must_equal(false) }
+    it {os[:family].must_equal('darwin')}
+    it { os.unix?.must_equal(true) }
+    it { os.bsd?.must_equal(true) }
+    it { os.esx?.must_equal(false) }
+  end
+
 end


### PR DESCRIPTION
Darwin is BSD, but it shouldn't be lumped in with BSD platforms. There's way too much different.

Signed-off-by: Tim Smith <tsmith@chef.io>