### PR TITLE
Return hostname from WinRM::Connection same as SSH::Connection

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -30,6 +30,7 @@ class Train::Transports::SSH
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
   class Connection < BaseConnection # rubocop:disable Metrics/ClassLength
+    attr_reader :hostname
     def initialize(options)
       super(options)
       @username               = @options.delete(:username)

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -103,6 +103,7 @@ module Train::Transports
         transport:                :negotiate,
         disable_sspi:             false,
         basic_auth_only:          false,
+        hostname:                 opts[:host],
         endpoint:                 opts[:endpoint],
         user:                     opts[:user],
         password:                 opts[:password],

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -30,6 +30,7 @@ class Train::Transports::WinRM
   class Connection < BaseConnection
     def initialize(options)
       super(options)
+      @hostname               = @options.delete(:hostname)
       @rdp_port               = @options.delete(:rdp_port)
       @connection_retries     = @options.delete(:connection_retries)
       @connection_retry_sleep = @options.delete(:connection_retry_sleep)

--- a/lib/train/transports/winrm_connection.rb
+++ b/lib/train/transports/winrm_connection.rb
@@ -28,6 +28,7 @@ class Train::Transports::WinRM
   #
   # @author Fletcher Nichol <fnichol@nichol.ca>
   class Connection < BaseConnection
+    attr_reader :hostname
     def initialize(options)
       super(options)
       @hostname               = @options.delete(:hostname)


### PR DESCRIPTION
Fixes #128 

The change allows these lines:
* https://github.com/chef/inspec/blob/master/lib/resources/ssl.rb#L48-L53

to be replaced with:
```
            inspec.backend.hostname
```