### PR TITLE
Convert `wmic` architecture to a normal standard

### DIFF
--- a/test/unit/extras/os_detect_windows_test.rb
+++ b/test/unit/extras/os_detect_windows_test.rb
@@ -17,6 +17,7 @@ describe 'os_detect_windows' do
       detector = OsDetectWindowsTester.new
       detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.3.9600]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=9600\r\r\nCaption=Microsoft Windows Server 2012 R2 Standard\r\r\nOSArchitecture=64-bit\r\r\nVersion=6.3.9600\r\r\n" , '', 0)
+      detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=9\r\r\n" , '', 0)
       detector
     }
 
@@ -24,7 +25,7 @@ describe 'os_detect_windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
       detector.platform[:name].must_equal('Windows Server 2012 R2 Standard')
-      detector.platform[:arch].must_equal('64-bit')
+      detector.platform[:arch].must_equal('x86_64')
       detector.platform[:release].must_equal('6.3.9600')
     end
   end
@@ -34,6 +35,7 @@ describe 'os_detect_windows' do
       detector = OsDetectWindowsTester.new
       detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=7601\r\r\nCaption=Microsoft Windows Server 2008 R2 Standard \r\r\nOSArchitecture=64-bit\r\r\nVersion=6.1.7601\r\r\n" , '', 0)
+      detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=9\r\r\n" , '', 0)
       detector
     }
 
@@ -41,7 +43,7 @@ describe 'os_detect_windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
       detector.platform[:name].must_equal('Windows Server 2008 R2 Standard')
-      detector.platform[:arch].must_equal('64-bit')
+      detector.platform[:arch].must_equal('x86_64')
       detector.platform[:release].must_equal('6.1.7601')
     end
   end
@@ -51,6 +53,7 @@ describe 'os_detect_windows' do
       detector = OsDetectWindowsTester.new
       detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 6.1.7601]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=7601\r\r\nCaption=Microsoft Windows 7 Enterprise \r\r\nOSArchitecture=32-bit\r\r\nVersion=6.1.7601\r\r\n\r\r\n" , '', 0)
+      detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=0\r\r\n" , '', 0)
       detector
     }
 
@@ -58,7 +61,7 @@ describe 'os_detect_windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
       detector.platform[:name].must_equal('Windows 7 Enterprise')
-      detector.platform[:arch].must_equal('32-bit')
+      detector.platform[:arch].must_equal('i386')
       detector.platform[:release].must_equal('6.1.7601')
     end
   end
@@ -68,6 +71,7 @@ describe 'os_detect_windows' do
       detector = OsDetectWindowsTester.new
       detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 10.0.10240]\r\n", '', 0)
       detector.backend.mock_command('wmic os get * /format:list',"\r\r\nBuildNumber=10240\r\r\nCaption=Microsoft Windows 10 Pro\r\r\nOSArchitecture=64-bit\r\r\nVersion=10.0.10240\r\r\n\r\r\n" , '', 0)
+      detector.backend.mock_command('wmic cpu get architecture /format:list',"\r\r\nArchitecture=9\r\r\n" , '', 0)
       detector
     }
 
@@ -75,7 +79,7 @@ describe 'os_detect_windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
       detector.platform[:name].must_equal('Windows 10 Pro')
-      detector.platform[:arch].must_equal('64-bit')
+      detector.platform[:arch].must_equal('x86_64')
       detector.platform[:release].must_equal('10.0.10240')
     end
   end
@@ -84,7 +88,8 @@ describe 'os_detect_windows' do
     let(:detector) {
       detector = OsDetectWindowsTester.new
       detector.backend.mock_command('cmd /c ver', "\r\nMicrosoft Windows [Version 4.10.1998]\r\n", '', 0)
-      detector.backend.mock_command('wmic os get * /format:list', nil , '', 1)
+      detector.backend.mock_command('wmic os get * /format:list', nil, '', 1)
+      detector.backend.mock_command('wmic cpu get architecture /format:list', nil, '', 1)
       detector
     }
 

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -24,7 +24,7 @@ describe 'windows local command' do
     os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
     os[:family].must_equal "windows"
     os[:release].must_equal '6.3.9600'
-    os[:arch].must_equal '64-bit'
+    os[:arch].must_equal 'x86_64'
   end
 
   it 'run echo test' do

--- a/test/windows/winrm_test.rb
+++ b/test/windows/winrm_test.rb
@@ -30,7 +30,7 @@ describe 'windows winrm command' do
     os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
     os[:family].must_equal 'windows'
     os[:release].must_equal '6.3.9600'
-    os[:arch].must_equal '64-bit'
+    os[:arch].must_equal 'x86_64'
   end
 
   it 'run echo test' do


### PR DESCRIPTION
Windows `wmic os get` outputs values that are not expected for CPU architecture.

For example, instead of `x86_64` or `i386` it returns `64-bit` and `32-bit`

This uses the output of `wmic cpu get architecture` and converts it to something that is expected from commands like `uname` or `arch`.

This is intended to resolve the InSpec issue brought up by @seththoenen [here](https://github.com/chef/inspec/issues/1100) and is an alternative to my InSpec PR [here](https://github.com/chef/inspec/pull/1102).