### PR TITLE
`Preparing modules for first use.` error message on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 version: "master-{build}"
 
-# fix for retrieving progress information for local execution
-# see: http://help.appveyor.com/discussions/problems/5170-progresspreference-not-works-always-shown-preparing-modules-for-first-use-in-stderr
-image: Previous Visual Studio 2015
-
 platform:
   - x64
 

--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -137,7 +137,7 @@ module Train::Extras
       # especially in local mode, we cannot be sure that we get a Powershell
       # we may just get a `cmd`.
       # TODO: we may want to opt for powershell.exe -command instead of `encodeCommand`
-      "powershell -encodedCommand #{encoded(safe_script(script))}"
+      "powershell -NoProfile -encodedCommand #{encoded(safe_script(script))}"
     end
 
     # suppress the progress stream from leaking to stderr


### PR DESCRIPTION
is a port of https://github.com/chef/train/pull/140 on to the latest master
fixes #153