### PR TITLE
Try to use ssh agent if no password or key files have been specified

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ end
 
 group :tools do
   gem 'pry', '~> 0.10'
+  gem 'rb-readline'
   gem 'license_finder'
   gem 'github_changelog_generator', '~> 1'
 end

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ train = Train.create('ssh',
   host: '1.2.3.4', port: 22, user: 'root', key_files: '/vagrant')
 ```
 
+If you don't specify the `key_files` and `password` options, SSH agent authentication will be attempted. For example:
+
+```ruby
+require 'train'
+train = Train.create('ssh', host: '1.2.3.4', port: 22, user: 'root')
+```
+
 **WinRM**
 
 ```ruby


### PR DESCRIPTION
If no password or private key is specified for ssh connections, try to use the ssh agent keys.

How it works:

```ruby
[05:42:37 ~/git/train (ap/add-agent-login)]$ ssh-add
Identity added: /Users/apop/.ssh/id_rsa (/Users/apop/.ssh/id_rsa)

[05:42:50 ~/git/train (ap/add-agent-login)]$ bundle exec pry
[1] pry(main)> require 'train'
=> true
[2] pry(main)> train = Train.create('ssh', host: 'ap-cs6.opschef.tv', port: 22, user: 'root')
=> #<Train::Transports::SSH:0x007fcefa482c10
 @logger=#<Logger:0x007fcefa482b48 @default_formatter=#<Logger::Formatter:0x007fcefa482b20 @datetime_format=nil>, @formatter=nil, @level=0, @logdev=#<Logger::LogDevice:0x007fcefa482ad0 @dev=#<IO:<STDOUT>>, @filename=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x007fcefa482a80>, @mon_owner=nil, @shift_age=nil, @shift_size=nil>, @progname=nil>,
 @options=
  {:host=>"ap-cs6.opschef.tv",
   :port=>22,
   :user=>"root",
   :shell=>false,
   :shell_options=>nil,
   :shell_command=>nil,
   :sudo=>false,
   :sudo_options=>nil,
   :sudo_password=>nil,
   :sudo_command=>nil,
   :key_files=>nil,
   :password=>nil,
   :keepalive=>true,
   :keepalive_interval=>60,
   :connection_timeout=>15,
   :connection_retries=>5,
   :connection_retry_sleep=>1,
   :max_wait_until_ready=>600,
   :compression=>false,
   :pty=>false,
   :compression_level=>0}>
[3] pry(main)> train.connection.run_command('hostname')
pick b6f42e5 try to use ssh agent if no password or key files have been specified Signed-off-by: Alex Pop <apop@chef.io>
D, [2016-11-21T17:44:48.843869 #9308] DEBUG -- : [SSH] Using Agent keys as no password or key file have been specified
...
D, [2016-11-21T17:44:49.549664 #9308] DEBUG -- : [SSH] root@ap-cs6.opschef.tv<{:user_known_hosts_file=>"/dev/null", :paranoid=>false, :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>15, :auth_methods=>["none", "publickey"], :keys_only=>nil, :keys=>nil, :password=>"<hidden>", :forward_agent=>nil, :user=>"root"}> (hostname)
=> #<struct Train::Extras::CommandResult stdout="ap-cs6.opschef.tv\n", stderr="", exit_status=0>
```

This enables tools like InSpec to run remote scans without having to link to a private key or use a password.