### PR TITLE
Add support for parallels & virtuozzo linux

### DIFF
--- a/lib/train/extras/os_detect_linux.rb
+++ b/lib/train/extras/os_detect_linux.rb
@@ -14,7 +14,7 @@ require 'train/extras/uname'
 module Train::Extras
   module DetectLinux # rubocop:disable Metrics/ModuleLength
     DEBIAN_FAMILY = %w{debian ubuntu linuxmint raspbian}.freeze
-    REDHAT_FAMILY = %w{centos redhat oracle scientific enterpriseenterprise xenserver cloudlinux ibm_powerkvm nexus_centos wrlinux}.freeze
+    REDHAT_FAMILY = %w{centos redhat oracle scientific enterpriseenterprise xenserver cloudlinux ibm_powerkvm nexus_centos wrlinux virtuozzo parallels}.freeze
     SUSE_FAMILY = %w{suse opensuse}.freeze
 
     include Train::Extras::LinuxLSB


### PR DESCRIPTION
Both parallels and virtuozzo linux are redhat derivatives and their suite of operating systems (virtuozzo linux, parallels cloud server etc) aren't detected correctly at the moment. Adding their OS to the REDHAT_FAMILY constant seems to get that fixed up

Before:

```
inspec shell -c 'os.params'
{:name=>"virtuozzo", :family=>"virtuozzo", :release=>"7.0.0", :arch=>"x86_64"}
```
```
inspec exec test.rb

Target:  local://


  Port 22
     ↺  The `port` resource is not supported on your OS yet.

Test Summary: 0 successful, 0 failures, 1 skipped
```


After:

```
inspec shell -c 'os.params'
{:name=>"virtuozzo", :family=>"redhat", :release=>"7.0.0", :arch=>"x86_64"}
```

```
Target:  local://


  Port 22
     ✔  should be listening

Test Summary: 1 successful, 0 failures, 0 skipped
```