### PR TITLE
Fix Net::SSH warning when passing nil option values

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -185,7 +185,7 @@ class Train::Transports::SSH
     # @api private
     def establish_connection(opts)
       logger.debug("[SSH] opening connection to #{self}")
-      Net::SSH.start(@hostname, @username, @options)
+      Net::SSH.start(@hostname, @username, @options.clone.delete_if { |_key, value| value.nil? })
     rescue *RESCUE_EXCEPTIONS_ON_ESTABLISH => e
       if (opts[:retries] -= 1) <= 0
         logger.warn("[SSH] connection failed, terminating (#{e.inspect})")


### PR DESCRIPTION
Net::SSH now complains if you pass in values that are nil as part of the option hash. Delete the nil values before passing to Net::SSH.