### PR TITLE
Fixed IPv6 URI parsing

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -61,7 +61,7 @@ module Train
     uri = parse_uri(conf[:target].to_s)
     unless uri.host.nil? and uri.scheme.nil?
       conf[:backend]  ||= uri.scheme
-      conf[:host]     ||= uri.host
+      conf[:host]     ||= uri.hostname
       conf[:port]     ||= uri.port
       conf[:user]     ||= uri.user
       conf[:password] ||= uri.password

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -129,6 +129,30 @@ describe Train do
       res.must_equal nu
     end
 
+    it 'supports IPv4 URIs' do
+      org = { target: 'mock://1.2.3.4:123' }
+      res = Train.target_config(org)
+      res[:backend].must_equal 'mock'
+      res[:host].must_equal '1.2.3.4'
+      res[:user].must_be_nil
+      res[:password].must_be_nil
+      res[:port].must_equal 123
+      res[:path].must_be_nil
+      res[:target].must_equal org[:target]
+    end
+
+    it 'supports IPv6 URIs' do
+      org = { target: 'mock://[abc::def]:123' }
+      res = Train.target_config(org)
+      res[:backend].must_equal 'mock'
+      res[:host].must_equal 'abc::def'
+      res[:user].must_be_nil
+      res[:password].must_be_nil
+      res[:port].must_equal 123
+      res[:path].must_be_nil
+      res[:target].must_equal org[:target]
+    end
+
     it 'supports empty URIs with schema://' do
       org = { target: 'mock://' }
       res = Train.target_config(org)


### PR DESCRIPTION
Currently if you pass a URI with a literal IPv6 address in it, it doesn't unwrap the square brackets around the IP. This leads to failures downstream when this is passed to `getaddrinfo`, which requires the IP without the brackets.

This PR just strips out the square brackets around the host parameter when parsing it from the URI by calling `URI.hostname` instead of `URI.host`.

Also added some unit tests for this case, and the IPv4 case.