### PR TITLE
Remove autoloads in favor of eager loading

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -3,6 +3,7 @@
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 
 require 'train/version'
+require 'train/options'
 require 'train/plugins'
 require 'train/errors'
 require 'uri'

--- a/lib/train/extras.rb
+++ b/lib/train/extras.rb
@@ -3,14 +3,14 @@
 # Author:: Dominik Richter (<dominik.richter@gmail.com>)
 
 module Train::Extras
-  autoload :CommandWrapper, 'train/extras/command_wrapper'
-  autoload :FileCommon,     'train/extras/file_common'
-  autoload :AixFile,        'train/extras/file_aix'
-  autoload :UnixFile,       'train/extras/file_unix'
-  autoload :LinuxFile,      'train/extras/file_linux'
-  autoload :WindowsFile,    'train/extras/file_windows'
-  autoload :OSCommon,       'train/extras/os_common'
-  autoload :Stat,           'train/extras/stat'
+  require 'train/extras/command_wrapper'
+  require 'train/extras/file_common'
+  require 'train/extras/file_unix'
+  require 'train/extras/file_aix'
+  require 'train/extras/file_linux'
+  require 'train/extras/file_windows'
+  require 'train/extras/os_common'
+  require 'train/extras/stat'
 
   CommandResult = Struct.new(:stdout, :stderr, :exit_status)
   LoginCommand = Struct.new(:command, :arguments)

--- a/lib/train/plugins.rb
+++ b/lib/train/plugins.rb
@@ -7,7 +7,7 @@ require 'train/errors'
 
 module Train
   class Plugins
-    autoload :Transport, 'train/plugins/transport'
+    require 'train/plugins/transport'
 
     class << self
       # Retrieve the current plugin registry, containing all plugin names

--- a/lib/train/plugins/transport.rb
+++ b/lib/train/plugins/transport.rb
@@ -13,7 +13,7 @@ class Train::Plugins
     include Train::Extras
     Train::Options.attach(self)
 
-    autoload :BaseConnection, 'train/plugins/base_connection'
+    require 'train/plugins/base_connection'
 
     # Initialize a new Transport object
     #

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -12,14 +12,14 @@ module Train::Transports
 
     include_options Train::Extras::CommandWrapper
 
-    autoload :File, 'train/transports/local_file'
-    autoload :OS,   'train/transports/local_os'
-
     def connection(_ = nil)
       @connection ||= Connection.new(@options)
     end
 
     class Connection < BaseConnection
+      require 'train/transports/local_file'
+      require 'train/transports/local_os'
+
       def initialize(options)
         super(options)
         @cmd_wrapper = nil

--- a/lib/train/transports/local_file.rb
+++ b/lib/train/transports/local_file.rb
@@ -6,7 +6,7 @@
 require 'train/extras'
 
 class Train::Transports::Local::Connection
-  class File < LinuxFile
+  class File < Train::Extras::LinuxFile
     def content
       @content ||= ::File.read(@path, encoding: 'UTF-8')
     rescue StandardError => _

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -36,7 +36,7 @@ module Train::Transports
   class SSH < Train.plugin(1)
     name 'ssh'
 
-    autoload :Connection, 'train/transports/ssh_connection'
+    require 'train/transports/ssh_connection'
 
     # add options for submodules
     include_options Train::Extras::CommandWrapper

--- a/lib/train/transports/winrm.rb
+++ b/lib/train/transports/winrm.rb
@@ -38,7 +38,7 @@ module Train::Transports
   class WinRM < Train.plugin(1)
     name 'winrm'
 
-    autoload :Connection, 'train/transports/winrm_connection'
+    require 'train/transports/winrm_connection'
 
     # common target configuration
     option :host, required: true


### PR DESCRIPTION
The Ruby Autoload feature has been deprecated as it is not thread safe.  This
patch replaces the use of autload with simple requires.

Ref: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/41149