### PR TITLE
Fix CoreOS platform detection

### DIFF
--- a/lib/train/extras/os_detect_linux.rb
+++ b/lib/train/extras/os_detect_linux.rb
@@ -85,10 +85,9 @@ module Train::Extras
       elsif !(raw = get_config('/etc/alpine-release')).nil?
         @platform[:name] = 'alpine'
         @platform[:release] = raw.strip
-      elsif !(raw = get_config('/etc/coreos/update.conf')).nil?
+      elsif !get_config('/etc/coreos/update.conf').nil?
         @platform[:name] = 'coreos'
-        meta = lsb_config(raw)
-        @platform[:release] = meta[:release]
+        @platform[:release] = lsb[:release]
       elsif !(os_info = fetch_os_release).nil?
         if os_info['ID_LIKE'] =~ /wrlinux/
           @platform[:name] = 'wrlinux'

--- a/test/unit/extras/os_detect_linux_test.rb
+++ b/test/unit/extras/os_detect_linux_test.rb
@@ -107,6 +107,18 @@ describe 'os_detect_linux' do
       end
     end
 
+    describe '/etc/coreos/update.conf' do
+      it 'sets the correct family/release for coreos' do
+        detector.stubs(:get_config).with('/etc/coreos/update.conf').returns('data')
+        detector.stubs(:lsb).returns({ id: 'Container Linux by CoreOS', release: 'coreos-version' })
+
+        detector.detect_linux_via_config.must_equal(true)
+        detector.platform[:name].must_equal('coreos')
+        detector.platform[:family].must_equal('coreos')
+        detector.platform[:release].must_equal('coreos-version')
+      end
+    end
+
     describe '/etc/os-release' do
       describe 'when not on a wrlinux build' do
         it 'does not set a platform family/release' do


### PR DESCRIPTION
Train v0.24.0 incorrectly detects the platform family of CoreOS: 

```
== Operating System Details 

Name:      coreos 
Family:    container linux by coreos 
Release:   1284.2.0 
Arch:      x86_64 
```

In `detect_linux_via_config` the detection falls thru because `@platform[:release]` is nil. The current code is: 

```
elsif !(raw = get_config('/etc/coreos/update.conf')).nil? 
  @platform[:name] = 'coreos' 
  meta = lsb_config(raw) 
  @platform[:release] = meta[:release] 
```
but `/etc/coreos/update.conf` is not in LSB format, so `meta[:release]` is nil. 

This PR uses `lsb[:release]` instead, which grabs the correct value and prevents the call to `detect_linux_via_lsb` which messes up the family.