### PR TITLE
detect operating system name for AIX

### DIFF
--- a/lib/train/extras/os_detect_unix.rb
+++ b/lib/train/extras/os_detect_unix.rb
@@ -14,6 +14,7 @@ module Train::Extras
       case uname_s.downcase
       when /aix/
         @platform[:family] = 'aix'
+        @platform[:name] = uname_s.lines[0].chomp
         out = @backend.run_command('uname -rvp').stdout
         m = out.match(/(\d+)\s+(\d+)\s+(.*)/)
         unless m.nil?


### PR DESCRIPTION
fixes #181 

```
b inspec shell -t ssh://root@172.29.153.189 --password 'abc'
Welcome to the interactive InSpec Shell
To find out how to use it, type: help

You are currently running on:

    OS platform:  AIX
    OS family:  aix
    OS release: 7.2

inspec> 
```