### PR TITLE
Fix to allow kitchen verify to pass with ssh transport

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -102,6 +102,7 @@ module Train::Transports
         else
           logger.debug('[SSH] Using Agent keys as no password or key file have been specified')
           options[:auth_methods].push('publickey')
+          options[:keys_only] = false # set keys_only to false to ensure agent keys are actually used
         end
       end
 


### PR DESCRIPTION
By default keys_only is set to true, this results in kitchen verify to fail unless a password or key file is explicitly set in .kitchen.yml, we can fix this by ensuring that not only publickey is pushed into the auth_methods, but also keys_only is set to false.