### PR TITLE
Return non-zero exit code for unknown mock command

### DIFF
--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -87,7 +87,8 @@ class Train::Transports::Mock
         STDERR.puts('    '+cmd.to_s.split("\n").join("\n    "))
         STDERR.puts('    SHA: ' + Digest::SHA256.hexdigest(cmd.to_s))
       end
-      mock_command(cmd)
+      # return a non-zero exit code
+      mock_command(cmd, nil, nil, 1)
     end
 
     def run_command(cmd)


### PR DESCRIPTION
If the command was not found, we should return a non-zero exit code. This would be similar to the behavior of the operating system that cannot find a given command

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>