### PR TITLE
return lowercase for platform name on bsd, esx and windows

### DIFF
--- a/lib/train/extras/os_detect_esx.rb
+++ b/lib/train/extras/os_detect_esx.rb
@@ -13,7 +13,7 @@ module Train::Extras
     def detect_esx
       if uname_s.downcase.chomp == 'vmkernel'
         @platform[:family] = 'esx'
-        @platform[:name] = uname_s.lines[0].chomp
+        @platform[:name] = uname_s.lines[0].downcase.chomp
         @platform[:release] = uname_r.lines[0].chomp
         true
       end

--- a/lib/train/extras/os_detect_unix.rb
+++ b/lib/train/extras/os_detect_unix.rb
@@ -10,11 +10,11 @@
 
 module Train::Extras
   module DetectUnix
-    def detect_via_uname # rubocop:disable Metrics/AbcSize
+    def detect_via_uname
       case uname_s.downcase
       when /aix/
         @platform[:family] = 'aix'
-        @platform[:name] = uname_s.lines[0].chomp
+        @platform[:name] = uname_name
         out = @backend.run_command('uname -rvp').stdout
         m = out.match(/(\d+)\s+(\d+)\s+(.*)/)
         unless m.nil?
@@ -23,23 +23,23 @@ module Train::Extras
         end
       when /hp-ux/
         @platform[:family] = 'hpux'
-        @platform[:name] = uname_s.lines[0].chomp
-        @platform[:release] = uname_r.lines[0].chomp
+        @platform[:name] = uname_name
+        @platform[:release] = uname_release
 
       when /freebsd/
         @platform[:family] = 'freebsd'
-        @platform[:name] = uname_s.lines[0].chomp
-        @platform[:release] = uname_r.lines[0].chomp
+        @platform[:name] = uname_name
+        @platform[:release] = uname_release
 
       when /netbsd/
         @platform[:family] = 'netbsd'
-        @platform[:name] = uname_s.lines[0].chomp
-        @platform[:release] = uname_r.lines[0].chomp
+        @platform[:name] = uname_name
+        @platform[:release] = uname_release
 
       when /openbsd/
         @platform[:family] = 'openbsd'
-        @platform[:name] = uname_s.lines[0].chomp
-        @platform[:release] = uname_r.lines[0].chomp
+        @platform[:name] = uname_name
+        @platform[:release] = uname_release
 
       when /sunos/
         detect_solaris
@@ -95,6 +95,16 @@ module Train::Extras
       # read architecture
       arch = @backend.run_command('uname -p')
       @platform[:arch] = arch.stdout.chomp if arch.exit_status == 0
+    end
+
+    private
+
+    def uname_name
+      uname_s.lines[0].downcase.chomp
+    end
+
+    def uname_release
+      uname_r.lines[0].chomp
     end
   end
 end

--- a/lib/train/extras/os_detect_windows.rb
+++ b/lib/train/extras/os_detect_windows.rb
@@ -50,6 +50,9 @@ module Train::Extras
         @platform[:build] = sys_info[:BuildNumber]
         @platform[:name] = sys_info[:Caption]
         @platform[:name] = @platform[:name].gsub('Microsoft', '').strip unless @platform[:name].empty?
+        # make sure the name is lowercase stipped
+        # "Windows Server 2012 R2 Standard" becomes "windows_server_2012_r2_standard"
+        @platform[:name] = @platform[:name].downcase.strip.tr(' ', '_').gsub(/[^\w-]/, '')
         @platform[:arch] = read_wmic_cpu
       end
     end

--- a/test/unit/extras/os_detect_windows_test.rb
+++ b/test/unit/extras/os_detect_windows_test.rb
@@ -24,7 +24,7 @@ describe 'os_detect_windows' do
     it 'sets the correct family/release for windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
-      detector.platform[:name].must_equal('Windows Server 2012 R2 Standard')
+      detector.platform[:name].must_equal('windows_server_2012_r2_standard')
       detector.platform[:arch].must_equal('x86_64')
       detector.platform[:release].must_equal('6.3.9600')
     end
@@ -42,7 +42,7 @@ describe 'os_detect_windows' do
     it 'sets the correct family/release for windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
-      detector.platform[:name].must_equal('Windows Server 2008 R2 Standard')
+      detector.platform[:name].must_equal('windows_server_2008_r2_standard')
       detector.platform[:arch].must_equal('x86_64')
       detector.platform[:release].must_equal('6.1.7601')
     end
@@ -60,7 +60,7 @@ describe 'os_detect_windows' do
     it 'sets the correct family/release for windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
-      detector.platform[:name].must_equal('Windows 7 Enterprise')
+      detector.platform[:name].must_equal('windows_7_enterprise')
       detector.platform[:arch].must_equal('i386')
       detector.platform[:release].must_equal('6.1.7601')
     end
@@ -78,7 +78,7 @@ describe 'os_detect_windows' do
     it 'sets the correct family/release for windows' do
       detector.detect_windows
       detector.platform[:family].must_equal('windows')
-      detector.platform[:name].must_equal('Windows 10 Pro')
+      detector.platform[:name].must_equal('windows_10_pro')
       detector.platform[:arch].must_equal('x86_64')
       detector.platform[:release].must_equal('10.0.10240')
     end

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -21,7 +21,7 @@ describe 'windows local command' do
 
   it 'verify os' do
     os = conn.os
-    os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
+    os[:name].must_equal 'windows_server_2012_r2_datacenter'
     os[:family].must_equal "windows"
     os[:release].must_equal '6.3.9600'
     os[:arch].must_equal 'x86_64'

--- a/test/windows/winrm_test.rb
+++ b/test/windows/winrm_test.rb
@@ -27,7 +27,7 @@ describe 'windows winrm command' do
 
   it 'verify os' do
     os = conn.os
-    os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
+    os[:name].must_equal 'windows_server_2012_r2_datacenter'
     os[:family].must_equal 'windows'
     os[:release].must_equal '6.3.9600'
     os[:arch].must_equal 'x86_64'


### PR DESCRIPTION
During investigation of https://github.com/chef/inspec/issues/1732 I discovered that we are not returning the operating system name as lowercase for BSD, ESX and Windows operating systems. This PR fixes this. 

Fixes #191 
Fixes https://github.com/chef/inspec/issues/1732


Therefore, instead of
```
inspec detect -t ssh://vagrant@127.0.0.1:2200 -i /path/to/private_key 

== Operating System Details

Name:      FreeBSD
Family:    freebsd
Release:   11.1-RELEASE-p1
Arch:      
```
we return the following now:
```
inspec detect -t ssh://vagrant@127.0.0.1:2200 -i /path/to/private_key

== Operating System Details

Name:      freebsd
Family:    freebsd
Release:   11.1-RELEASE-p1
Arch:      
```

Just be aware that this is breaking existing tests for BSD unix and windows!
- `FreeBSD` becomes `freebsd`
- `Windows Server 2012 R2 Standard` becomes `windows_server_2012_r2_standard`