### PR TITLE
Fix inconsistent link_path behavior

### DIFF
--- a/lib/train/transports/local_file.rb
+++ b/lib/train/transports/local_file.rb
@@ -21,6 +21,14 @@ class Train::Transports::Local::Connection
       end
     end
 
+    def path
+      if symlink? && @follow_symlink
+        link_path
+      else
+        @path
+      end
+    end
+
     def link_path
       return nil unless symlink?
       begin

--- a/test/unit/transports/local_file_test.rb
+++ b/test/unit/transports/local_file_test.rb
@@ -49,6 +49,24 @@ describe 'local file transport' do
     end
   end
 
+  describe '#path' do
+    it 'returns the path if it is not a symlink' do
+      File.stub :symlink?, false do
+        filename = rand.to_s
+        connection.file(filename).path.must_equal filename
+      end
+    end
+
+    it 'returns the link_path if it is a symlink' do
+      File.stub :symlink?, true do
+        file_obj = connection.file(rand.to_s)
+        file_obj.stub :link_path, '/path/to/resolved_link' do
+          file_obj.path.must_equal '/path/to/resolved_link'
+        end
+      end
+    end
+  end
+
   describe 'file metadata' do
     let(:stat) { Struct.new(:mode, :size, :mtime, :uid, :gid) }
     let(:uid) { rand }


### PR DESCRIPTION
When calling `path` on a file using the local transport, it would call Train::Extras::LinuxFile.path which would in turn call read_target_path if the file was a symlink (which calls the `readlink` OS program). The return value would be stored in `@link_path` which is then returned whenever `link_path` is called on the file.

`readlink` does not operate the same way on macOS like it does on Linux variants. Specifically, in the case of cascading symlinks (a -> b -> c), it will return "c" on Linux but "b" on macOS. This leads to inconsistent behavior depending on if you call `path` before `link_path` since `path` stores a value in `@link_path`. For example:

Example 1 (calling path before link_path):
```
inspec> a = file('/tmp/top_link')
=> File /tmp/top_link
inspec> a.path
=> "/tmp/middle_link"
inspec> a.link_path
=> "/tmp/middle_link"
```

Example 2 (calling link_path before path):
```
inspec> a = file('/tmp/top_link')
=> File /tmp/top_link
inspec> a.link_path
=> "/private/tmp/actual_file"
inspec> a.path
=> "/private/tmp/actual_file"
```

Plus, we have the Ruby stdlib calls we can and should use when local so Windows, Linux, and macOS users have a consistent experience. Therefore, this change implements a `path` method override on the Local File class to avoid LinuxFile from getting in the way.