### PR TITLE
[win-perf][proof-of-concept] run PS in a server locally

### DIFF
--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -6,6 +6,9 @@
 require 'train/plugins'
 require 'mixlib/shellout'
 
+require 'win32/process'
+require 'base64'
+
 module Train::Transports
   class Local < Train.plugin(1)
     name 'local'
@@ -22,15 +25,22 @@ module Train::Transports
 
       def initialize(options)
         super(options)
+        @server = start_server()
         @cmd_wrapper = nil
         @cmd_wrapper = CommandWrapper.load(self, options)
       end
 
+      def close
+        Net::HTTP.post(URI("http://localhost:8888"), "exit")
+      end
+
       def run_command(cmd)
-        cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
-        res = Mixlib::ShellOut.new(cmd)
-        res.run_command
-        CommandResult.new(res.stdout, res.stderr, res.exitstatus)
+        resp = Net::HTTP.post(URI("http://localhost:8888/"), cmd)
+        if resp.code == "200"
+          CommandResult.new(resp.body, '', 0)
+        else
+          CommandResult.new('', resp.body, 1)
+        end
       rescue Errno::ENOENT => _
         CommandResult.new('', '', 1)
       end
@@ -50,6 +60,71 @@ module Train::Transports
       def uri
         'local://'
       end
+
+      def start_server
+        server_script = <<EOF
+$ProgressPreference='SilentlyContinue'
+Function Start-Server {
+    Process {
+        $ErrorActionPreference = "Stop"
+
+        $listener = New-Object System.Net.HttpListener
+        $listener.Prefixes.Add("http://localhost:8888/")
+        try {
+            $listener.Start()
+            while ($true) {
+                $statusCode = 200
+                $context = $listener.GetContext()
+                $request = $context.Request
+
+                $command = ""
+                $size = $request.ContentLength64 + 1
+                $buffer = New-Object byte[] $size
+                do {
+                    $count = $request.InputStream.Read($buffer, 0, $size)
+                    $command += $request.ContentEncoding.GetString($buffer, 0, $count)
+                } until($count -lt $size)
+                $request.InputStream.Close()
+
+                if ($command -eq "exit") {
+                    return
+                }
+
+                try {
+                    $script = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
+                    $commandOutput = & $script
+                } catch {
+                    $commandOutput = $_
+                    $statusCode = 500
+                }
+
+                $commandOutput = $commandOutput | Out-String
+
+                if (!$commandOutput) {
+                    $commandOutput = [string]::Empty
+                }
+                Write-Verbose $commandOutput
+                $response = $context.Response
+                $response.StatusCode = $statusCode
+                $buffer = [System.Text.Encoding]::UTF8.GetBytes($commandOutput)
+
+                $response.ContentLength64 = $buffer.Length
+                $output = $response.OutputStream
+                $output.Write($buffer,0,$buffer.Length)
+                $output.Close()
+            }
+        } finally {
+            $listener.Stop()
+        }
+    }
+}
+Start-Server
+EOF
+        encoded = Base64.strict_encode64(server_script.encode('UTF-16LE', 'UTF-8'))
+        cmd = "powershell -noprofile -executionpolicy bypass -noninteractive -encodedcommand #{encoded}"
+        Process.create(command_line: cmd)
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Proof of Concept - Do Not Merge

we incur a significant overhead when running windows commands
locally because each command needs to execute within a new
powershell instance. this adds an overhead of approximately
250ms per powershell request.

the changes in the sd/win-perf branch of inspec go a ways
towards reducing the number of powershell commands that are
executed, but they will never overcome the overhead that's
baked in for each one of those calls.

this change is a PROOF OF CONCEPT for what it would look
like to have a long-running powershell process that inspec/train
can send commands to. in this POC, it's implemented as an HTTP
server written in powershell that executed the body of POST
requests and has a special `exit` command to kill the process.

on `master` of inspec, this reduces the execution time of the
`windows-baseline` profile from 30s to 13s. when combined with
the `sd/win-perf` branch of inspec, the execution time is
further reduced to 9s.

Signed-off-by: Stephen Delano <stephen@chef.io>