### PR TITLE
Bump to net-ssh 4.2, fix bad net-ssh deprecation

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -134,7 +134,7 @@ module Train::Transports
       {
         logger:                 logger,
         user_known_hosts_file:  '/dev/null',
-        paranoid:               false,
+        verify_host_key:        false,
         hostname:               opts[:host],
         port:                   opts[:port],
         username:               opts[:user],

--- a/test/unit/transports/ssh_test.rb
+++ b/test/unit/transports/ssh_test.rb
@@ -49,6 +49,19 @@ describe 'ssh transport' do
     end
   end
 
+  describe 'connection options' do
+    let(:ssh) { cls.new({ host: 'dummy' }) }
+    let(:connection_options) { ssh.send(:connection_options, {}) }
+
+    it 'does not set a paranoid option - deprecated in net-ssh 4.2' do
+      connection_options.key?(:paranoid).must_equal false
+    end
+
+    it 'sets a verify_host_key option, replacement for paranoid' do
+      connection_options[:verify_host_key].must_equal false
+    end
+  end
+
   describe 'opening a connection' do
     let(:ssh) { cls.new(conf) }
     let(:connection) { ssh.connection }

--- a/train.gemspec
+++ b/train.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout', '~> 2.0'
   # net-ssh 3.x drops Ruby 1.9 support, so this constraint could be raised when
   # 1.9 support is no longer needed here or for Inspec
-  spec.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
+  spec.add_dependency 'net-ssh', '~> 4.2'
   spec.add_dependency 'net-scp', '~> 1.2'
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'


### PR DESCRIPTION
net-ssh 4.2 was released and attempted to deprecate the `paranoid` connection options. However, it was not done properly and can cause SSH connection failures. Additionally, the new replacement flag (verify_host_key) does not work < 4.2.

This change pins train to net-ssh 4.2 and greater and ceases use of the paranoid flag.