### PR TITLE
Continue to support older net-ssh while fixing 4.2 deprecation

### DIFF
--- a/train.gemspec
+++ b/train.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mixlib-shellout', '~> 2.0'
   # net-ssh 3.x drops Ruby 1.9 support, so this constraint could be raised when
   # 1.9 support is no longer needed here or for Inspec
-  spec.add_dependency 'net-ssh', '~> 4.2'
+  spec.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
   spec.add_dependency 'net-scp', '~> 1.2'
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'


### PR DESCRIPTION
In #197, we bumped our dependency on net-ssh to ~> 4.2 to address a deprecation of the `paranoid` option made in net-ssh 4.2.0. Unfortunately, this is causing users of newer InSpec versions to not be able to use InSpec with Chef v12 due to net-ssh v3 in use in that version.

This change reverts the net-ssh pin to be looser and dynamically chooses the connection option to use depending on the version of net-ssh in use. This will avoid the deprecation warning and allow us to support newer net-ssh versions.