### PR TITLE
add basic qnx support for train

### DIFF
--- a/lib/train/extras.rb
+++ b/lib/train/extras.rb
@@ -7,6 +7,7 @@ module Train::Extras
   require 'train/extras/file_common'
   require 'train/extras/file_unix'
   require 'train/extras/file_aix'
+  require 'train/extras/file_qnx'
   require 'train/extras/file_linux'
   require 'train/extras/file_windows'
   require 'train/extras/os_common'

--- a/lib/train/extras/file_qnx.rb
+++ b/lib/train/extras/file_qnx.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# author: Christoph Hartmann
+# author: Dominik Richter
+
+module Train::Extras
+  class QnxFile < UnixFile
+    def content
+      cat = 'cat'
+      cat = '/proc/boot/cat' if @backend.os[:release].to_i >= 7
+      @content ||= case
+                   when !exist?
+                     nil
+                   else
+                     @backend.run_command("#{cat} #{@spath}").stdout || ''
+                   end
+    end
+
+    def type
+      if @backend.run_command("file #{@spath}").stdout.include?("directory")
+        return :directory
+      else
+        return :file
+      end
+    end
+
+    %w{
+      mode owner group uid gid mtime size selinux_label link_path mounted stat
+    }.each do |field|
+      define_method field.to_sym do
+        fail NotImplementedError, "QNX does not implement the #{m}() method yet."
+      end
+    end
+  end
+end

--- a/lib/train/extras/file_qnx.rb
+++ b/lib/train/extras/file_qnx.rb
@@ -16,7 +16,7 @@ module Train::Extras
     end
 
     def type
-      if @backend.run_command("file #{@spath}").stdout.include?("directory")
+      if @backend.run_command("file #{@spath}").stdout.include?('directory')
         return :directory
       else
         return :file

--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -66,12 +66,12 @@ module Train::Extras
       },
       'darwin' => %w{
         darwin
-      },
+      }
     }
 
     OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware fedora amazon} + OS['redhat'] + OS['debian'] + OS['suse']
 
-    OS['unix'] = %w{unix aix hpux} + OS['linux'] + OS['solaris'] + OS['bsd']
+    OS['unix'] = %w{unix aix hpux qnx} + OS['linux'] + OS['solaris'] + OS['bsd']
 
     # Helper methods to check the OS type
     # Provides methods in the form of: linux?, unix?, solaris? ...

--- a/lib/train/extras/os_common.rb
+++ b/lib/train/extras/os_common.rb
@@ -66,7 +66,7 @@ module Train::Extras
       },
       'darwin' => %w{
         darwin
-      }
+      },
     }
 
     OS['linux'] = %w{linux alpine arch coreos exherbo gentoo slackware fedora amazon} + OS['redhat'] + OS['debian'] + OS['suse']

--- a/lib/train/extras/os_detect_unix.rb
+++ b/lib/train/extras/os_detect_unix.rb
@@ -41,6 +41,12 @@ module Train::Extras
         @platform[:name] = uname_s.lines[0].chomp
         @platform[:release] = uname_r.lines[0].chomp
 
+      when /qnx/
+        @platform[:family] = 'qnx'
+        @platform[:name] = uname_s.lines[0].chomp.downcase
+        @platform[:release] = uname_r.lines[0].chomp
+        @platform[:arch] = uname_m
+
       when /sunos/
         detect_solaris
       else

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -65,6 +65,8 @@ class Train::Transports::SSH
           AixFile.new(self, path)
         elsif os.solaris?
           UnixFile.new(self, path)
+        elsif os[:name] == 'qnx'
+          QnxFile.new(self, path)
         else
           LinuxFile.new(self, path)
         end


### PR DESCRIPTION
This PR adds basic support for QNX 6 and 7. It extends the system detection and the file transfer.

QNX 6
[![asciicast](https://asciinema.org/a/142434.png)](https://asciinema.org/a/142434)

QNX 7
[![asciicast](https://asciinema.org/a/142436.png)](https://asciinema.org/a/142436)