### PR TITLE
Build a complete mock OS object

### DIFF
--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -65,7 +65,7 @@ class Train::Transports::Mock
 
     def initialize(conf = nil)
       super(conf)
-      @os = OS.new(self, family: 'unknown')
+      mock_os
       @commands = {}
     end
 
@@ -73,8 +73,9 @@ class Train::Transports::Mock
       'mock://'
     end
 
-    def mock_os(value)
-      @os = OS.new(self, value)
+    def mock_os(value = {})
+      os_params = { name: 'unknown', family: 'unknown', release: 'unknown', arch: 'unknown' }.merge(value)
+      @os = OS.new(self, os_params)
     end
 
     def mock_command(cmd, stdout = nil, stderr = nil, exit_status = 0)


### PR DESCRIPTION
InSpec expects there to be four parameters on every OS object: name, release, family, and arch. When the mock backend is used, only "family" is ever populated. When evaluating blocks, such as an only_if block, when the mock backend is used, errors will be encountered if someone tries to do something like:

os.name.include?('something')

... because `os.name` will be nil during an inspec check, for example.

This change properly populates all four expected parameters of the OS whenever the mock backend is used. The `mock_os` method still allows for one-off setting of the value as needed for unit tests, but it's now merged with the default four values.

Related to chef/inspec#2250