### PR TITLE
Ensure a `mounted?` method exists for all File classes, including Mock

### DIFF
--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -140,5 +140,18 @@ module Train
         @path
       end
     end
+
+    # if the OS-specific file class supports inquirying as to whether the
+    # file/device is mounted, the #mounted method should return a command
+    # object whose stdout will not be nil if indeed the device is mounted.
+    #
+    # if the OS-specific file class does not support checking for mount
+    # status, the method should not be implemented and this method will
+    # return false.
+    def mounted?
+      return false unless respond_to?(:mounted)
+
+      !mounted.nil? && !mounted.stdout.nil? && !mounted.stdout.empty?
+    end
   end
 end

--- a/lib/train/file/local/unix.rb
+++ b/lib/train/file/local/unix.rb
@@ -50,10 +50,6 @@ module Train
             @backend.run_command("mount | grep -- ' on #{@spath} '")
         end
 
-        def mounted?
-          !mounted.nil? && !mounted.stdout.nil? && !mounted.stdout.empty?
-        end
-
         def grouped_into?(sth)
           group == sth
         end

--- a/lib/train/file/remote/unix.rb
+++ b/lib/train/file/remote/unix.rb
@@ -31,10 +31,6 @@ module Train
           )
         end
 
-        def mounted?
-          !mounted.nil? && !mounted.stdout.nil? && !mounted.stdout.empty?
-        end
-
         def mounted
           @mounted ||=
             @backend.run_command("mount | grep -- ' on #{@spath} '")


### PR DESCRIPTION
InSpec unit tests are failing against Train 0.29.0 because it does
not contain a `mounted?` method on the Mock File class.

Signed-off-by: Adam Leff <adam@leff.co>