### PR TITLE
Add unix_mode_mask method to Train::File::Local::Unix

### DIFF
--- a/lib/train/file/local/unix.rb
+++ b/lib/train/file/local/unix.rb
@@ -54,6 +54,16 @@ module Train
           group == sth
         end
 
+        def unix_mode_mask(owner, type)
+          o = UNIX_MODE_OWNERS[owner.to_sym]
+          return nil if o.nil?
+
+          t = UNIX_MODE_TYPES[type.to_sym]
+          return nil if t.nil?
+
+          t & o
+        end
+
         private
 
         def pw_username(uid)
@@ -67,6 +77,19 @@ module Train
         rescue ArgumentError => _
           nil
         end
+
+        UNIX_MODE_OWNERS = {
+          all:   00777,
+          owner: 00700,
+          group: 00070,
+          other: 00007,
+        }.freeze
+
+        UNIX_MODE_TYPES = {
+          r: 00444,
+          w: 00222,
+          x: 00111,
+        }.freeze
       end
     end
   end

--- a/test/unit/file/local/unix_test.rb
+++ b/test/unit/file/local/unix_test.rb
@@ -113,7 +113,9 @@ describe Train::File::Local::Unix do
   describe '#unix_mode_mask' do
     let(:file_tester) do
       Class.new(cls) do
-        define_method :type { :file }
+        define_method :type do
+          :file
+        end
       end.new(nil, nil, false)
     end
 

--- a/test/unit/file/local/unix_test.rb
+++ b/test/unit/file/local/unix_test.rb
@@ -5,7 +5,7 @@ require 'train/transports/local'
 
 describe Train::File::Local::Unix do
   let(:cls) { Train::File::Local::Unix }
-  
+
   let(:backend) {
     backend = Train::Transports::Mock.new.connection
     backend.mock_os({ family: 'linux' })
@@ -86,8 +86,8 @@ describe Train::File::Local::Unix do
     it 'grouped_into' do
       meta_stub :stat, statres do
         connection.file(rand.to_s).grouped_into?('group').must_equal true
-      end  
-    end  
+      end
+    end
 
     it 'recognizes selinux label' do
       meta_stub :stat, statres do
@@ -107,6 +107,38 @@ describe Train::File::Local::Unix do
           connection.file(rand.to_s).source.selinux_label.must_equal label
         end
       end
+    end
+  end
+
+  describe '#unix_mode_mask' do
+    let(:file_tester) do
+      Class.new(cls) do
+        define_method :type { :file }
+      end.new(nil, nil, false)
+    end
+
+    it 'check owner mode calculation' do
+      file_tester.unix_mode_mask('owner', 'x').must_equal 0100
+      file_tester.unix_mode_mask('owner', 'w').must_equal 0200
+      file_tester.unix_mode_mask('owner', 'r').must_equal 0400
+    end
+
+    it 'check group mode calculation' do
+      file_tester.unix_mode_mask('group', 'x').must_equal 0010
+      file_tester.unix_mode_mask('group', 'w').must_equal 0020
+      file_tester.unix_mode_mask('group', 'r').must_equal 0040
+    end
+
+    it 'check other mode calculation' do
+      file_tester.unix_mode_mask('other', 'x').must_equal 0001
+      file_tester.unix_mode_mask('other', 'w').must_equal 0002
+      file_tester.unix_mode_mask('other', 'r').must_equal 0004
+    end
+
+    it 'check all mode calculation' do
+      file_tester.unix_mode_mask('all', 'x').must_equal 0111
+      file_tester.unix_mode_mask('all', 'w').must_equal 0222
+      file_tester.unix_mode_mask('all', 'r').must_equal 0444
     end
   end
 end


### PR DESCRIPTION
During the refactor, the `#unix_mode_mask` method for Unix files was only added to the Remote class. It's still needed for the Local class.

Fixes chef/inspec#2314