### PR TITLE
Fix inspec mock tests

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -425,16 +425,31 @@ module Train::Platforms::Detect::Specifications
             # for now we are going to just try each platform
             true
           }
-      plat.name('darwin').title('Darwin').in_family('bsd')
+      plat.family('darwin').in_family('bsd')
           .detect {
             cmd = unix_file_contents('/usr/bin/sw_vers')
             if unix_uname_s =~ /darwin/i || !cmd.nil?
-              @platform[:name] = unix_uname_s.lines[0].chomp
-              @platform[:release] = cmd[/^ProductVersion:\s+(.+)$/, 1] || unix_uname_r.lines[0].chomp
-              @platform[:build] = cmd[/^BuildVersion:\s+(.+)$/, 1]
+              unless cmd.nil?
+                m = cmd.match(/^ProductVersion:\s+(.+)$/)
+                @platform[:release] = m.nil? ? nil : m[1]
+                m = cmd.match(/^BuildVersion:\s+(.+)$/)
+                @platform[:build] = m.nil? ? nil : m[1]
+              end
+              @platform[:release] = unix_uname_r.lines[0].chomp if @platform[:release].nil?
               @platform[:arch] = unix_uname_m
               true
             end
+          }
+      plat.name('mac_os_x').title('MAC OS X').in_family('darwin')
+          .detect {
+            cmd = unix_file_contents('/System/Library/CoreServices/SystemVersion.plist')
+            true if cmd =~ /Mac OS X/i
+          }
+      plat.name('darwin').title('Darwin').in_family('darwin')
+          .detect {
+            # must be some other type of darwin
+            @platform[:name] = unix_uname_s.lines[0].chomp
+            true
           }
       plat.name('freebsd').title('Freebsd').in_family('bsd')
           .detect {

--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -440,7 +440,7 @@ module Train::Platforms::Detect::Specifications
               true
             end
           }
-      plat.name('mac_os_x').title('MAC OS X').in_family('darwin')
+      plat.name('mac_os_x').title('macOS X').in_family('darwin')
           .detect {
             cmd = unix_file_contents('/System/Library/CoreServices/SystemVersion.plist')
             true if cmd =~ /Mac OS X/i

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -73,6 +73,7 @@ class Train::Transports::Mock
     def mock_os(value = {})
       # if a user passes a nil value, set to an empty hash so the merge still succeeds
       value ||= {}
+      value.each { |k, v| value[k] = 'unknown' if v.nil? }
       value = { name: 'unknown', family: 'unknown', release: 'unknown', arch: 'unknown' }.merge(value)
 
       platform = Train::Platforms.name(value[:name])

--- a/test/unit/platforms/platform_test.rb
+++ b/test/unit/platforms/platform_test.rb
@@ -362,7 +362,21 @@ describe 'platform' do
     let(:os) { mock_platform('darwin') }
     it { os.solaris?.must_equal(false) }
     it { os.linux?.must_equal(false) }
-    it { os[:family].must_equal('bsd') }
+    it { os[:family].must_equal('darwin') }
+    it { os.bsd?.must_equal(true) }
+    it { os.darwin?.must_equal(true) }
+    it { os.unix?.must_equal(true) }
+    it { os.bsd?.must_equal(true) }
+    it { os.esx?.must_equal(false) }
+  end
+
+  describe 'with platform set to mac_os_x' do
+    let(:os) { mock_platform('mac_os_x') }
+    it { os.solaris?.must_equal(false) }
+    it { os.linux?.must_equal(false) }
+    it { os[:family].must_equal('darwin') }
+    it { os.bsd?.must_equal(true) }
+    it { os.darwin?.must_equal(true) }
     it { os.unix?.must_equal(true) }
     it { os.bsd?.must_equal(true) }
     it { os.esx?.must_equal(false) }


### PR DESCRIPTION
Inspec has some unique test cases where it sets nil platform name and uses a mac_os_x platform in some cases. I have created a actual mac_os_x platform and refined darwin checks. This change also updates mock os properties to be unknown if set to nil.

Inspec also expects a darwin family for its cases and documentation. That was added.

The new platform checks have been tested on darwin/osx boxes. Local Inspec tests are all passing with this change.

Signed-off-by: Jared Quick <jquick@chef.io>