### PR TITLE
Use the sanitized file path for remote linux files

### DIFF
--- a/lib/train/file/remote/linux.rb
+++ b/lib/train/file/remote/linux.rb
@@ -8,7 +8,7 @@ module Train
       class Linux < Train::File::Remote::Unix
         def content
           return @content if defined?(@content)
-          @content = @backend.run_command("cat #{@path} || echo -n").stdout
+          @content = @backend.run_command("cat #{@spath} || echo -n").stdout
           return @content unless @content.empty?
           @content = nil if directory? or size.nil? or size > 0
           @content

--- a/test/integration/bootstrap.sh
+++ b/test/integration/bootstrap.sh
@@ -12,6 +12,8 @@ chmod 0765 /tmp/file
 echo -n 'hello suid/sgid/sticky' > /tmp/sfile
 chmod 7765 /tmp/sfile
 
+echo -n 'hello space' > /tmp/spaced\ file
+
 test ! -e /tmp/pipe && \
   mkfifo /tmp/pipe
 

--- a/test/integration/cookbooks/test/recipes/prep_files.rb
+++ b/test/integration/cookbooks/test/recipes/prep_files.rb
@@ -21,6 +21,10 @@ file '/tmp/sfile' do
   content 'hello suid/sgid/sticky'
 end
 
+file '/tmp/spaced file' do
+  content 'hello space'
+end
+
 directory '/tmp/folder' do
   mode '0567'
   owner 'root'

--- a/test/integration/tests/path_file_test.rb
+++ b/test/integration/tests/path_file_test.rb
@@ -89,4 +89,11 @@ describe 'file interface' do
       file.mode.must_equal(07765)
     end
   end
+
+  describe 'regular file' do
+    let(:file) { backend.file('/tmp/spaced file') }
+    it 'has content' do
+      file.content.must_equal('hello space')
+    end
+  end
 end

--- a/test/unit/file/remote/linux_test.rb
+++ b/test/unit/file/remote/linux_test.rb
@@ -42,6 +42,12 @@ describe Train::File::Remote::Linux do
     cls.new(backend, 'path').content.must_be_nil
   end
 
+  it 'reads file contents' do
+    out = rand.to_s
+    backend.mock_command('cat /spaced\\ path || echo -n', out)
+    cls.new(backend, '/spaced path').content.must_equal out
+  end
+
   it 'checks for file existance' do
     backend.mock_command('test -e path', true)
     cls.new(backend, 'path').exist?.must_equal true


### PR DESCRIPTION
Had a test start failing recently and tracked it down to remote linux file
resources no longer handling spaces in paths as of the refactor in 0.29.0.

The test passes again after applying this change.

Signed-off-by: Jonathan Hartman <j@hartman.io>