### PR TITLE
Fix regressions in 0.29.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 branches:
   only:
   - master
+  - release-0.29.2
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ platform:
 environment:
   winrm_user: test_user
   winrm_pass: Pass@word1
-  bundler_url: https://rubygems.org/downloads/bundler-1.9.9.gem
 
   matrix:
     - ruby_version: "22"
@@ -41,8 +40,6 @@ install:
   - ps: Write-Host $env:PATH
   - ruby --version
   - gem --version
-  - appveyor DownloadFile -Url %bundler_url% -FileName bundler.gem
-  - gem install --local bundler --quiet --no-document
   - bundler --version
   - ruby -r rubygems -e "p Gem.path"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ clone_depth: 1
 branches:
   only:
     - master
+    - release-0.29.2
 
 cache:
   - vendor/bundle -> appveyor.yml

--- a/lib/train/file/local/unix.rb
+++ b/lib/train/file/local/unix.rb
@@ -54,6 +54,16 @@ module Train
           group == sth
         end
 
+        def unix_mode_mask(owner, type)
+          o = UNIX_MODE_OWNERS[owner.to_sym]
+          return nil if o.nil?
+
+          t = UNIX_MODE_TYPES[type.to_sym]
+          return nil if t.nil?
+
+          t & o
+        end
+
         private
 
         def pw_username(uid)
@@ -67,6 +77,19 @@ module Train
         rescue ArgumentError => _
           nil
         end
+
+        UNIX_MODE_OWNERS = {
+          all:   00777,
+          owner: 00700,
+          group: 00070,
+          other: 00007,
+        }.freeze
+
+        UNIX_MODE_TYPES = {
+          r: 00444,
+          w: 00222,
+          x: 00111,
+        }.freeze
       end
     end
   end

--- a/lib/train/file/remote/linux.rb
+++ b/lib/train/file/remote/linux.rb
@@ -8,7 +8,7 @@ module Train
       class Linux < Train::File::Remote::Unix
         def content
           return @content if defined?(@content)
-          @content = @backend.run_command("cat #{@path} || echo -n").stdout
+          @content = @backend.run_command("cat #{@spath} || echo -n").stdout
           return @content unless @content.empty?
           @content = nil if directory? or size.nil? or size > 0
           @content

--- a/test/integration/bootstrap.sh
+++ b/test/integration/bootstrap.sh
@@ -12,6 +12,8 @@ chmod 0765 /tmp/file
 echo -n 'hello suid/sgid/sticky' > /tmp/sfile
 chmod 7765 /tmp/sfile
 
+echo -n 'hello space' > /tmp/spaced\ file
+
 test ! -e /tmp/pipe && \
   mkfifo /tmp/pipe
 

--- a/test/integration/cookbooks/test/recipes/prep_files.rb
+++ b/test/integration/cookbooks/test/recipes/prep_files.rb
@@ -21,6 +21,10 @@ file '/tmp/sfile' do
   content 'hello suid/sgid/sticky'
 end
 
+file '/tmp/spaced file' do
+  content 'hello space'
+end
+
 directory '/tmp/folder' do
   mode '0567'
   owner 'root'

--- a/test/integration/tests/path_file_test.rb
+++ b/test/integration/tests/path_file_test.rb
@@ -89,4 +89,11 @@ describe 'file interface' do
       file.mode.must_equal(07765)
     end
   end
+
+  describe 'regular file' do
+    let(:file) { backend.file('/tmp/spaced file') }
+    it 'has content' do
+      file.content.must_equal('hello space')
+    end
+  end
 end

--- a/test/unit/file/local/unix_test.rb
+++ b/test/unit/file/local/unix_test.rb
@@ -5,7 +5,7 @@ require 'train/transports/local'
 
 describe Train::File::Local::Unix do
   let(:cls) { Train::File::Local::Unix }
-  
+
   let(:backend) {
     backend = Train::Transports::Mock.new.connection
     backend.mock_os({ family: 'linux' })
@@ -86,8 +86,8 @@ describe Train::File::Local::Unix do
     it 'grouped_into' do
       meta_stub :stat, statres do
         connection.file(rand.to_s).grouped_into?('group').must_equal true
-      end  
-    end  
+      end
+    end
 
     it 'recognizes selinux label' do
       meta_stub :stat, statres do
@@ -107,6 +107,40 @@ describe Train::File::Local::Unix do
           connection.file(rand.to_s).source.selinux_label.must_equal label
         end
       end
+    end
+  end
+
+  describe '#unix_mode_mask' do
+    let(:file_tester) do
+      Class.new(cls) do
+        define_method :type do
+          :file
+        end
+      end.new(nil, nil, false)
+    end
+
+    it 'check owner mode calculation' do
+      file_tester.unix_mode_mask('owner', 'x').must_equal 0100
+      file_tester.unix_mode_mask('owner', 'w').must_equal 0200
+      file_tester.unix_mode_mask('owner', 'r').must_equal 0400
+    end
+
+    it 'check group mode calculation' do
+      file_tester.unix_mode_mask('group', 'x').must_equal 0010
+      file_tester.unix_mode_mask('group', 'w').must_equal 0020
+      file_tester.unix_mode_mask('group', 'r').must_equal 0040
+    end
+
+    it 'check other mode calculation' do
+      file_tester.unix_mode_mask('other', 'x').must_equal 0001
+      file_tester.unix_mode_mask('other', 'w').must_equal 0002
+      file_tester.unix_mode_mask('other', 'r').must_equal 0004
+    end
+
+    it 'check all mode calculation' do
+      file_tester.unix_mode_mask('all', 'x').must_equal 0111
+      file_tester.unix_mode_mask('all', 'w').must_equal 0222
+      file_tester.unix_mode_mask('all', 'r').must_equal 0444
     end
   end
 end

--- a/test/unit/file/remote/linux_test.rb
+++ b/test/unit/file/remote/linux_test.rb
@@ -42,6 +42,12 @@ describe Train::File::Remote::Linux do
     cls.new(backend, 'path').content.must_be_nil
   end
 
+  it 'reads file contents' do
+    out = rand.to_s
+    backend.mock_command('cat /spaced\\ path || echo -n', out)
+    cls.new(backend, '/spaced path').content.must_equal out
+  end
+
   it 'checks for file existance' do
     backend.mock_command('test -e path', true)
     cls.new(backend, 'path').exist?.must_equal true


### PR DESCRIPTION
This PR is a set of cherry-picks to cut a 0.29 patch release to correct some issues that snuck into 0.29.1. We are branching off of v0.29.1 rather than releasing master because of the volume of unreleased changes currently sitting on master that we do not wish to release during the US Thanksgiving week.

The cherry-picks are from the following PRs which are already merged to master:
 - #218 (use sanitized name in path to account for files with spaces in the name)
 - #215 (fix the omission of the unix_mode_mask method on remote unix files)
