### PR TITLE
Use named pipe to decrease local Windows runtime

### DIFF
--- a/lib/train/extras/command_wrapper.rb
+++ b/lib/train/extras/command_wrapper.rb
@@ -121,43 +121,6 @@ module Train::Extras
     end
   end
 
-  # this is required if you run locally on windows,
-  # winrm connections provide a PowerShell shell automatically
-  # TODO: only activate in local mode
-  class PowerShellCommand < CommandWrapperBase
-    Train::Options.attach(self)
-
-    def initialize(backend, options)
-      @backend = backend
-      validate_options(options)
-    end
-
-    def run(script)
-      # wrap the script to ensure we always run it via powershell
-      # especially in local mode, we cannot be sure that we get a Powershell
-      # we may just get a `cmd`.
-      # TODO: we may want to opt for powershell.exe -command instead of `encodeCommand`
-      "powershell -NoProfile -encodedCommand #{encoded(safe_script(script))}"
-    end
-
-    # suppress the progress stream from leaking to stderr
-    def safe_script(script)
-      "$ProgressPreference='SilentlyContinue';" + script
-    end
-
-    # Encodes the script so that it can be passed to the PowerShell
-    # --EncodedCommand argument.
-    # @return [String] The UTF-16LE base64 encoded script
-    def encoded(script)
-      encoded_script = safe_script(script).encode('UTF-16LE', 'UTF-8')
-      Base64.strict_encode64(encoded_script)
-    end
-
-    def to_s
-      'PowerShell CommandWrapper'
-    end
-  end
-
   class CommandWrapper
     include_options LinuxCommand
 
@@ -168,10 +131,6 @@ module Train::Extras
         msg = res.verify
         fail Train::UserError, "Sudo failed: #{msg}" unless msg.nil?
         res
-      # only use powershell command for local transport. winrm transport
-      # uses powershell as default
-      elsif transport.os.windows? && transport.class == Train::Transports::Local::Connection
-        PowerShellCommand.new(transport, options)
       end
     end
   end

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -16,28 +16,18 @@ module Train::Transports
       @connection ||= Connection.new(@options)
     end
 
-    class Connection < BaseConnection # rubocop:disable Metrics/ClassLength
-      require 'json'
-      require 'base64'
-      require 'securerandom'
-
+    class Connection < BaseConnection
       def initialize(options)
         super(options)
         @cmd_wrapper = nil
         @cmd_wrapper = CommandWrapper.load(self, options)
-        if @platform.windows?
-          begin
-            @pipe = acquire_named_pipe
-          rescue
-            @pipe = false
-          end
-        end
+        @platform = platform
       end
 
       def run_command(cmd)
-        if defined?(@pipe) && @pipe
-          res = run_powershell_using_named_pipe(cmd)
-          CommandResult.new(res['stdout'], res['stderr'], res['exitstatus'])
+        if defined?(@platform) && @platform.windows?
+          @windows_runner ||= WindowsRunner.new
+          @windows_runner.run_command(cmd)
         else
           cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
           res = Mixlib::ShellOut.new(cmd)
@@ -53,12 +43,11 @@ module Train::Transports
       end
 
       def file(path)
-        @files[path] ||= \
-          if os.windows?
-            Train::File::Local::Windows.new(self, path)
-          else
-            Train::File::Local::Unix.new(self, path)
-          end
+        @files[path] ||= if os.windows?
+                           Train::File::Local::Windows.new(self, path)
+                         else
+                           Train::File::Local::Unix.new(self, path)
+                         end
       end
 
       def login_command
@@ -69,81 +58,131 @@ module Train::Transports
         'local://'
       end
 
-      private
+      class WindowsRunner
+        require 'json'
+        require 'base64'
+        require 'securerandom'
 
-      def acquire_named_pipe
-        pipe_name = "inspec_#{SecureRandom.hex}"
-        pipe_location = "//localhost/pipe/#{pipe_name}"
-        start_named_pipe_server(pipe_name) unless File.exist?(pipe_location)
-
-        # Try to acquire pipe for 10 seconds with 0.1 second intervals.
-        # This allows time for PowerShell to start the pipe
-        pipe = nil
-        100.times do
-          begin
-            pipe = open(pipe_location, 'r+')
-            break
-          rescue
-            sleep 0.1
-          end
+        def initialize
+          @pipe = acquire_pipe
         end
-        fail "Could not open named pipe #{pipe_location}" if pipe.nil?
 
-        pipe
-      end
+        def run_command(cmd)
+          res = @pipe ? run_via_pipe(cmd) : run_via_shellout(cmd)
+          Local::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
+        rescue Errno::ENOENT => _
+          CommandResult.new('', '', 1)
+        end
 
-      def run_powershell_using_named_pipe(script)
-        script = "$ProgressPreference='SilentlyContinue';" + script
-        encoded_script = Base64.strict_encode64(script)
-        @pipe.puts(encoded_script)
-        @pipe.flush
-        JSON.parse(Base64.decode64(@pipe.readline))
-      end
+        private
 
-      def start_named_pipe_server(pipe_name)
-        require 'win32/process'
+        def acquire_pipe
+          pipe_name = Dir.entries('//./pipe/').find { |f| f =~ /inspec_/ }
 
-        script = <<-EOF
-          $ErrorActionPreference = 'Stop'
+          return create_pipe("inspec_#{SecureRandom.hex}") if pipe_name.nil?
 
-          $pipeServer = New-Object System.IO.Pipes.NamedPipeServerStream('#{pipe_name}')
-          $pipeReader = New-Object System.IO.StreamReader($pipeServer)
-          $pipeWriter = New-Object System.IO.StreamWriter($pipeServer)
+          begin
+            pipe = open("//./pipe/#{pipe_name}", 'r+')
+          rescue
+            # Pipes are closed when a Train connection ends. When running
+            # multiple independent scans (e.g. Unit tests) the pipe will be
+            # unavailable because the previous process is closing it.
+            # This creates a new pipe in that case
+            pipe = create_pipe("inspec_#{SecureRandom.hex}")
+          end
 
-          $pipeServer.WaitForConnection()
+          return false if pipe.nil?
 
-          # Create loop to receive and process user commands/scripts
-          $clientConnected = $true
-          while($clientConnected) {
-            $input = $pipeReader.ReadLine()
-            $command = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($input))
+          pipe
+        end
 
-            # Execute user command/script and convert result to JSON
-            $scriptBlock = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
-            try {
-              $stdout = & $scriptBlock | Out-String
-              $result = @{ 'stdout' = $stdout ; 'stderr' = ''; 'exitstatus' = 0 }
-            } catch {
-              $stderr = $_ | Out-String
-              $result = @{ 'stdout' = ''; 'stderr' = $_; 'exitstatus' = 1 }
+        def create_pipe(pipe_name)
+          start_pipe_server(pipe_name)
+
+          pipe = nil
+
+          # PowerShell needs time to create pipe.
+          100.times do
+            begin
+              pipe = open("//./pipe/#{pipe_name}", 'r+')
+              break
+            rescue
+              sleep 0.1
+            end
+          end
+
+          return false if pipe.nil?
+
+          pipe
+        end
+
+        def run_via_shellout(script)
+          # Prevent progress stream from leaking into stderr
+          script = "$ProgressPreference='SilentlyContinue';" + script
+
+          # Encode script so PowerShell can use it
+          script = script.encode('UTF-16LE', 'UTF-8')
+          base64_script = Base64.strict_encode64(script)
+
+          cmd = "powershell -NoProfile -EncodedCommand #{base64_script}"
+
+          res = Mixlib::ShellOut.new(cmd)
+          res.run_command
+        end
+
+        def run_via_pipe(script)
+          script = "$ProgressPreference='SilentlyContinue';" + script
+          encoded_script = Base64.strict_encode64(script)
+          @pipe.puts(encoded_script)
+          @pipe.flush
+          OpenStruct.new(JSON.parse(Base64.decode64(@pipe.readline)))
+        end
+
+        def start_pipe_server(pipe_name)
+          require 'win32/process'
+
+          script = <<-EOF
+            $ErrorActionPreference = 'Stop'
+
+            $pipeServer = New-Object System.IO.Pipes.NamedPipeServerStream('#{pipe_name}')
+            $pipeReader = New-Object System.IO.StreamReader($pipeServer)
+            $pipeWriter = New-Object System.IO.StreamWriter($pipeServer)
+
+            $pipeServer.WaitForConnection()
+
+            # Create loop to receive and process user commands/scripts
+            $clientConnected = $true
+            while($clientConnected) {
+              $input = $pipeReader.ReadLine()
+              $command = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($input))
+
+              # Execute user command/script and convert result to JSON
+              $scriptBlock = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
+              try {
+                $stdout = & $scriptBlock | Out-String
+                $result = @{ 'stdout' = $stdout ; 'stderr' = ''; 'exitstatus' = 0 }
+              } catch {
+                $stderr = $_ | Out-String
+                $result = @{ 'stdout' = ''; 'stderr' = $_; 'exitstatus' = 1 }
+              }
+              $resultJSON = $result | ConvertTo-JSON
+
+              # Encode JSON in Base64 and write to pipe
+              $encodedResult = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($resultJSON))
+              $pipeWriter.WriteLine($encodedResult)
+              $pipeWriter.Flush()
             }
-            $resultJSON = $result | ConvertTo-JSON
+          EOF
 
-            # Encode JSON in Base64 and write to pipe
-            $encodedResult = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($resultJSON))
-            $pipeWriter.WriteLine($encodedResult)
-            $pipeWriter.Flush()
-          }
-        EOF
+          utf8_script = script.encode('UTF-16LE', 'UTF-8')
+          base64_script = Base64.strict_encode64(utf8_script)
+          cmd = "powershell -NoProfile -ExecutionPolicy bypass -NonInteractive -EncodedCommand #{base64_script}"
 
-        utf8_script = script.encode('UTF-16LE', 'UTF-8')
-        base64_script = Base64.strict_encode64(utf8_script)
-        cmd = "powershell -NoProfile -ExecutionPolicy bypass -NonInteractive -EncodedCommand #{base64_script}"
+          server_pid = Process.create(command_line: cmd).process_id
 
-        server_pid = Process.create(command_line: cmd).process_id
-
-        # Ensure process is killed when the Train process exits
-        at_exit { Process.kill('KILL', server_pid) }
+          # Ensure process is killed when the Train process exits
+          at_exit { Process.kill('KILL', server_pid) }
+        end
       end
 
       def run_command_via_connection(cmd)

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -120,27 +120,8 @@ module Train::Transports
         private
 
         def acquire_pipe
-          current_pipe = Dir.entries('//./pipe/').find { |f| f =~ /inspec_/ }
+          pipe_name = "inspec_#{SecureRandom.hex}"
 
-          pipe = nil
-          if current_pipe.nil?
-            pipe = create_pipe("inspec_#{SecureRandom.hex}")
-          else
-            begin
-              pipe = open("//./pipe/#{current_pipe}", 'r+')
-            rescue
-              # Pipes are closed when a Train connection ends. When running
-              # multiple independent scans (e.g. Unit tests) the pipe will be
-              # unavailable because the previous process is closing it.
-              # This creates a new pipe in that case
-              pipe = create_pipe("inspec_#{SecureRandom.hex}")
-            end
-          end
-
-          pipe
-        end
-
-        def create_pipe(pipe_name)
           start_pipe_server(pipe_name)
 
           pipe = nil

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -16,7 +16,10 @@ module Train::Transports
       @connection ||= Connection.new(@options)
     end
 
-    class Connection < BaseConnection
+    class Connection < BaseConnection # rubocop:disable Metrics/ClassLength
+      require 'json'
+      require 'base64'
+
       def initialize(options)
         super(options)
         @cmd_wrapper = nil
@@ -37,11 +40,108 @@ module Train::Transports
 
       private
 
+      def run_powershell_using_named_pipe(script)
+        pipe = nil
+        # Try to acquire pipe for 10 seconds with 0.1 second intervals.
+        # Removing this can result in instability due to the pipe being
+        # temporarily unavailable.
+        100.times do
+          begin
+            pipe = open('//localhost/pipe/InSpec', 'r+')
+            break
+          rescue
+            sleep 0.1
+          end
+        end
+        fail 'Could not open pipe `//localhost/pipe/InSpec`' if pipe.nil?
+        # Prevent progress stream from leaking to stderr
+        script = "$ProgressPreference='SilentlyContinue';" + script
+        encoded_script = Base64.strict_encode64(script)
+        pipe.puts(encoded_script)
+        pipe.flush
+        result = JSON.parse(Base64.decode64(pipe.readline))
+        pipe.close
+        result
+      end
+
+      def start_named_pipe_server # rubocop:disable Metrics/MethodLength
+        require 'win32/process'
+
+        script = <<-EOF
+          $ProgressPreference = 'SilentlyContinue'
+          $ErrorActionPreference = 'Stop'
+
+          Function Execute-UserCommand($userInput) {
+            $command = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($userInput))
+
+            $scriptBlock = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
+            try {
+              $stdout = & $scriptBlock | Out-String
+              $result = @{ 'stdout' = $stdout ; 'stderr' = ''; 'exitstatus' = 0 }
+            } catch {
+              $stderr = $_ | Out-String
+              $result = @{ 'stdout' = ''; 'stderr' = $_; 'exitstatus' = 1 }
+            }
+            return $result | ConvertTo-JSON
+          }
+
+          Function Start-PipeServer {
+            while($true) {
+              # Attempt to acquire a pipe for 10 seconds, trying every 100 milliseconds
+              for($i=1; $i -le 100; $i++) {
+                try {
+                  $pipeServer = New-Object System.IO.Pipes.NamedPipeServerStream('InSpec', [System.IO.Pipes.PipeDirection]::InOut)
+                  break
+                } catch {
+                  Start-Sleep -m 100
+                  if($i -eq 100) { throw }
+                }
+              }
+              $pipeReader = New-Object System.IO.StreamReader($pipeServer)
+              $pipeWriter = New-Object System.IO.StreamWriter($pipeServer)
+
+              $pipeServer.WaitForConnection()
+              $pipeWriter.AutoFlush = $true
+
+              $clientConnected = $true
+              while($clientConnected) {
+                $input = $pipeReader.ReadLine()
+
+                if($input -eq $null) {
+                  $clientConnected = $false
+                  $pipeServer.Dispose()
+                } else {
+                  $result = Execute-UserCommand($input)
+                  $encodedResult = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($result))
+                  $pipeWriter.WriteLine($encodedResult)
+                }
+              }
+            }
+          }
+          Start-PipeServer
+        EOF
+
+        utf8_script = script.encode('UTF-16LE', 'UTF-8')
+        base64_script = Base64.strict_encode64(utf8_script)
+        cmd = "powershell -NoProfile -ExecutionPolicy bypass -NonInteractive -EncodedCommand #{base64_script}"
+
+        server_pid = Process.create(command_line: cmd).process_id
+
+        # Ensure process is killed when the Train process exits
+        at_exit { Process.kill('KILL', server_pid) }
+      end
+
       def run_command_via_connection(cmd)
-        cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
-        res = Mixlib::ShellOut.new(cmd)
-        res.run_command
-        CommandResult.new(res.stdout, res.stderr, res.exitstatus)
+        if defined?(@platform) && @platform.windows?
+          start_named_pipe_server unless File.exist?('//localhost/pipe/InSpec')
+          res = run_powershell_using_named_pipe(cmd)
+          CommandResult.new(res['stdout'], res['stderr'], res['exitstatus'])
+        else
+          cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
+          res = Mixlib::ShellOut.new(cmd)
+          res.run_command
+          CommandResult.new(res.stdout, res.stderr, res.exitstatus)
+        end
       rescue Errno::ENOENT => _
         CommandResult.new('', '', 1)
       end

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -16,7 +16,7 @@ module Train::Transports
       @connection ||= Connection.new(@options)
     end
 
-    class Connection < BaseConnection
+    class Connection < BaseConnection # rubocop:disable Metrics/ClassLength
       require 'json'
       require 'base64'
       require 'securerandom'
@@ -25,11 +25,17 @@ module Train::Transports
         super(options)
         @cmd_wrapper = nil
         @cmd_wrapper = CommandWrapper.load(self, options)
-        @pipe = acquire_named_pipe if @platform.windows?
+        if @platform.windows?
+          begin
+            @pipe = acquire_named_pipe
+          rescue
+            @pipe = false
+          end
+        end
       end
 
       def run_command(cmd)
-        if defined?(@pipe)
+        if defined?(@pipe) && @pipe
           res = run_powershell_using_named_pipe(cmd)
           CommandResult.new(res['stdout'], res['stderr'], res['exitstatus'])
         else

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -70,7 +70,6 @@ module Train::Transports
         require 'win32/process'
 
         script = <<-EOF
-          $ProgressPreference = 'SilentlyContinue'
           $ErrorActionPreference = 'Stop'
 
           Function Execute-UserCommand($userInput) {

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -77,7 +77,7 @@ module Train::Transports
         script = <<-EOF
           $ErrorActionPreference = 'Stop'
 
-          $pipeServer = New-Object System.IO.Pipes.NamedPipeServerStream('#{pipe_name}', [System.IO.Pipes.PipeDirection]::InOut)
+          $pipeServer = New-Object System.IO.Pipes.NamedPipeServerStream('#{pipe_name}')
           $pipeReader = New-Object System.IO.StreamReader($pipeServer)
           $pipeWriter = New-Object System.IO.StreamWriter($pipeServer)
 

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -43,11 +43,12 @@ module Train::Transports
       end
 
       def file(path)
-        @files[path] ||= if os.windows?
-                           Train::File::Local::Windows.new(self, path)
-                         else
-                           Train::File::Local::Unix.new(self, path)
-                         end
+        @files[path] ||= \
+          if os.windows?
+            Train::File::Local::Windows.new(self, path)
+          else
+            Train::File::Local::Unix.new(self, path)
+          end
       end
 
       def login_command

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -24,7 +24,7 @@ module Train::Transports
 
         # While OS is being discovered, use the GenericRunner
         @runner = GenericRunner.new
-        @runner.cmd_wrapper = Local::CommandWrapper.load(self, options)
+        @runner.cmd_wrapper = CommandWrapper.load(self, options)
 
         if os.windows?
           # Attempt to use a named pipe but fallback to ShellOut if that fails

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -21,11 +21,11 @@ module Train::Transports
         super(options)
         @cmd_wrapper = nil
         @cmd_wrapper = CommandWrapper.load(self, options)
-        @platform = platform
+        @os = os
       end
 
       def run_command(cmd)
-        if defined?(@platform) && @platform.windows?
+        if defined?(@os) && @os.windows?
           @windows_runner ||= WindowsRunner.new
           @windows_runner.run_command(cmd)
         else

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -6,11 +6,12 @@ require 'train/transports/local'
 class TransportHelper
   attr_accessor :transport
 
-  def initialize(type = :mock)
+  def initialize(user_opts = {})
+    opts = {platform_name: 'mock', family_hierarchy: ['mock']}.merge(user_opts)
     Train::Platforms::Detect::Specifications::OS.load
-    plat = Train::Platforms.name('mock')
+    plat = Train::Platforms.name(opts[:platform_name])
+    plat.family_hierarchy = opts[:family_hierarchy]
     plat.add_platform_methods
-    plat.stubs(:windows?).returns(true) if type == :windows
     Train::Platforms::Detect.stubs(:scan).returns(plat)
     @transport = Train::Transports::Local.new
   end
@@ -96,7 +97,9 @@ describe 'local transport' do
   end
 
   describe 'when running on Windows' do
-    let(:connection) { TransportHelper.new(:windows).transport.connection }
+    let(:connection) do
+      TransportHelper.new(family_hierarchy: ['windows']).transport.connection
+    end
     let(:runner) { mock }
 
     it 'uses `WindowsPipeRunner` by default' do

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -6,10 +6,11 @@ require 'train/transports/local'
 class TransportHelper
   attr_accessor :transport
 
-  def initialize
+  def initialize(type = :mock)
     Train::Platforms::Detect::Specifications::OS.load
     plat = Train::Platforms.name('mock').in_family('linux')
     plat.add_platform_methods
+    plat.stubs(:windows?).returns(true) if type == :windows
     Train::Platforms::Detect.stubs(:scan).returns(plat)
     @transport = Train::Transports::Local.new
   end
@@ -96,8 +97,8 @@ describe 'local transport' do
 
   describe 'when running on Windows' do
     let(:conn) do
-      Train::Platforms::Platform.any_instance.stubs(:windows?).returns(true)
-      Train::Transports::Local.new.connection
+      TransportHelper.new(:windows).transport
+      transport.connection
     end
 
     let(:runner) { mock }

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -8,7 +8,7 @@ class TransportHelper
 
   def initialize(type = :mock)
     Train::Platforms::Detect::Specifications::OS.load
-    plat = Train::Platforms.name('mock').in_family('linux')
+    plat = Train::Platforms.name('mock')
     plat.add_platform_methods
     plat.stubs(:windows?).returns(true) if type == :windows
     Train::Platforms::Detect.stubs(:scan).returns(plat)
@@ -96,10 +96,7 @@ describe 'local transport' do
   end
 
   describe 'when running on Windows' do
-    let(:conn) do
-      TransportHelper.new(:windows).transport
-      transport.connection
-    end
+    let(:connection) { TransportHelper.new(:windows).transport.connection }
 
     let(:runner) { mock }
 
@@ -113,7 +110,7 @@ describe 'local transport' do
         .never
 
       runner.expects(:run_command).with('not actually executed')
-      conn.run_command('not actually executed')
+      connection.run_command('not actually executed')
     end
 
     it 'uses `WindowsShellRunner` when a named pipe is not available' do
@@ -126,7 +123,7 @@ describe 'local transport' do
         .returns(runner)
 
       runner.expects(:run_command).with('not actually executed')
-      conn.run_command('not actually executed')
+      connection.run_command('not actually executed')
     end
   end
 end

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -97,7 +97,6 @@ describe 'local transport' do
 
   describe 'when running on Windows' do
     let(:connection) { TransportHelper.new(:windows).transport.connection }
-
     let(:runner) { mock }
 
     it 'uses `WindowsPipeRunner` by default' do

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -45,10 +45,10 @@ describe 'windows local command' do
     connection = conn
 
     # Prevent named pipe from being created
-    Train::Transports::Local::Connection::WindowsRunner
+    Train::Transports::Local::Connection::WindowsPipeRunner
       .any_instance
       .stubs(:acquire_pipe)
-      .returns(false)
+      .returns(nil)
 
     # Verify pipe was not created
     SecureRandom.stubs(:hex).returns('minitest')

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -44,7 +44,8 @@ describe 'windows local command' do
     # Must call `:conn` early so we can stub `SecureRandom`
     connection = conn
 
-    SecureRandom.stubs(:hex).returns('with_pipe')
+    # Verify pipe is created by using PowerShell to check pipe location
+    SecureRandom.stubwass(:hex).returns('with_pipe')
     cmd = connection.run_command('Get-ChildItem //./pipe/ | Where-Object { $_.Name -Match "inspec_with_pipe" }')
     cmd.stdout.wont_be_nil
     cmd.stderr.must_equal ''
@@ -60,7 +61,7 @@ describe 'windows local command' do
       .stubs(:acquire_pipe)
       .returns(nil)
 
-    # Verify pipe was not created
+    # Verify pipe was not created by using PowerShell to check pipe location
     SecureRandom.stubs(:hex).returns('minitest')
     cmd = connection.run_command('Get-ChildItem //./pipe/ | Where-Object { $_.Name -Match "inspec_minitest" }')
     cmd.stdout.must_equal ''

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -51,7 +51,7 @@ describe 'windows local command' do
     cmd.stderr.must_equal ''
   end
 
-  it 'when named pipe is not available it runs `Mixlib::Shellout`' do
+  it 'when named pipe is not available it runs `Mixlib::ShellOut`' do
     # Must call `:conn` early so we can stub `:acquire_pipe`
     connection = conn
 

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -40,6 +40,14 @@ describe 'windows local command' do
     cmd.stderr.must_equal ''
   end
 
+  it 'uses a named pipe if available' do
+    # Verify pipe is created by stubbing the random parts of the name
+    SecureRandom.stubs(:hex).returns('with_pipe')
+    cmd = conn.run_command('Get-ChildItem //./pipe/ | Where-Object { $_.Name -Match "inspec_with_pipe" }')
+    cmd.stdout.wont_be_nil
+    cmd.stderr.must_equal ''
+  end
+
   it 'when named pipe is not available it runs `Mixlib::Shellout`' do
     # Must call `:conn` early so we can stub `:acquire_pipe`
     connection = conn

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -41,9 +41,11 @@ describe 'windows local command' do
   end
 
   it 'uses a named pipe if available' do
-    # Verify pipe is created by stubbing the random parts of the name
+    # Must call `:conn` early so we can stub `SecureRandom`
+    connection = conn
+
     SecureRandom.stubs(:hex).returns('with_pipe')
-    cmd = conn.run_command('Get-ChildItem //./pipe/ | Where-Object { $_.Name -Match "inspec_with_pipe" }')
+    cmd = connection.run_command('Get-ChildItem //./pipe/ | Where-Object { $_.Name -Match "inspec_with_pipe" }')
     cmd.stdout.wont_be_nil
     cmd.stderr.must_equal ''
   end

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -45,7 +45,7 @@ describe 'windows local command' do
     connection = conn
 
     # Verify pipe is created by using PowerShell to check pipe location
-    SecureRandom.stubwass(:hex).returns('with_pipe')
+    SecureRandom.expects(:hex).returns('with_pipe')
     cmd = connection.run_command('Get-ChildItem //./pipe/ | Where-Object { $_.Name -Match "inspec_with_pipe" }')
     cmd.stdout.wont_be_nil
     cmd.stderr.must_equal ''
@@ -58,7 +58,7 @@ describe 'windows local command' do
     # Prevent named pipe from being created
     Train::Transports::Local::Connection::WindowsPipeRunner
       .any_instance
-      .stubs(:acquire_pipe)
+      .expects(:acquire_pipe)
       .returns(nil)
 
     # Verify pipe was not created by using PowerShell to check pipe location

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -40,6 +40,23 @@ describe 'windows local command' do
     cmd.stderr.must_equal ''
   end
 
+  it 'when named pipe is not available it runs `Mixlib::Shellout`' do
+    # Must call `:conn` early so we can stub `:acquire_pipe`
+    connection = conn
+
+    # Prevent named pipe from being created
+    Train::Transports::Local::Connection::WindowsRunner
+      .any_instance
+      .stubs(:acquire_pipe)
+      .returns(false)
+
+    # Verify pipe was not created
+    SecureRandom.stubs(:hex).returns('minitest')
+    cmd = connection.run_command('Get-ChildItem //./pipe/ | Where-Object { $_.Name -Match "inspec_minitest" }')
+    cmd.stdout.must_equal ''
+    cmd.stderr.must_equal ''
+  end
+
   describe 'file' do
     before do
       @temp = Tempfile.new('foo')


### PR DESCRIPTION
This uses PowerShell to spawn a process that listens on a named pipe for
Base64 encoded commands and executes them. This drastically decreases
the total runtime when running locally on Windows by using a single
PowerShell session to execute commands instead of spawning a new session
for each command.

Huge thanks to @sdelano for the initial idea!

Signed-off-by: Jerry Aldrich <jerryaldrichiii@gmail.com>