### PR TITLE
Change the mock transport name to be 'mock'

### DIFF
--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -74,7 +74,7 @@ class Train::Transports::Mock
       # if a user passes a nil value, set to an empty hash so the merge still succeeds
       value ||= {}
       value.each { |k, v| value[k] = 'unknown' if v.nil? }
-      value = { name: 'mock', family: 'unknown', release: 'unknown', arch: 'unknown' }.merge(value)
+      value = { name: 'mock', family: 'mock', release: 'unknown', arch: 'unknown' }.merge(value)
 
       platform = Train::Platforms.name(value[:name])
       platform.family_hierarchy = mock_os_hierarchy(platform).flatten

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -74,7 +74,7 @@ class Train::Transports::Mock
       # if a user passes a nil value, set to an empty hash so the merge still succeeds
       value ||= {}
       value.each { |k, v| value[k] = 'unknown' if v.nil? }
-      value = { name: 'unknown', family: 'unknown', release: 'unknown', arch: 'unknown' }.merge(value)
+      value = { name: 'mock', family: 'unknown', release: 'unknown', arch: 'unknown' }.merge(value)
 
       platform = Train::Platforms.name(value[:name])
       platform.family_hierarchy = mock_os_hierarchy(platform).flatten

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -81,8 +81,8 @@ describe 'mock transport' do
   end
 
   describe 'when accessing a mocked os' do
-    it 'has the default mock os faily set to unknown' do
-      connection.os[:name].must_equal 'unknown'
+    it 'has the default mock os faily set to mock' do
+      connection.os[:name].must_equal 'mock'
     end
 
     it 'sets the OS to the mocked value' do
@@ -122,7 +122,7 @@ describe 'mock transport' do
 
     it 'properly handles a nil value' do
       connection.mock_os(nil)
-      connection.os[:name].must_equal 'unknown'
+      connection.os[:name].must_equal 'mock'
       connection.os[:family].must_equal 'unknown'
     end
   end

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -123,7 +123,7 @@ describe 'mock transport' do
     it 'properly handles a nil value' do
       connection.mock_os(nil)
       connection.os[:name].must_equal 'mock'
-      connection.os[:family].must_equal 'unknown'
+      connection.os[:family].must_equal 'mock'
     end
   end
 


### PR DESCRIPTION
This change allows us to distinguish mock transports from other legitimate unknown os transports upstream in inspec. 

Signed-off-by: Jared Quick <jquick@chef.io>