### PR TITLE
Add release detect for failback debian

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -110,6 +110,7 @@ module Train::Platforms::Detect::Specifications
             end
 
             # if we get this far we have to be some type of debian
+            @platform[:release] = unix_file_contents('/etc/debian_version').chomp
             true
           }
 

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -79,7 +79,7 @@ describe 'os_detect' do
       lsb_release = "DISTRIB_ID=#{id}\nDISTRIB_RELEASE=#{version}"
       files = {
         '/etc/lsb-release' => lsb_release,
-        '/etc/debian_version' => 'data',
+        '/etc/debian_version' => '11',
       }
       scan_with_files('linux', files)
     end
@@ -124,7 +124,7 @@ describe 'os_detect' do
 
         platform[:name].must_equal('debian')
         platform[:family].must_equal('debian')
-        platform[:release].must_equal('12.99')
+        platform[:release].must_equal('11')
       end
     end
   end


### PR DESCRIPTION
There is a bug with the debian failback detect not setting the release correctly.

Before and after:
![screen shot 2017-12-05 at 11 03 49 am](https://user-images.githubusercontent.com/574637/33616813-059668d2-d9ac-11e7-9322-0c71533cef24.png)


Signed-off-by: Jared Quick <jquick@chef.io>