### PR TITLE
Allow runner specifications for local connections

### DIFF
--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -20,8 +20,8 @@ module Train::Transports
       def initialize(options)
         super(options)
 
-        @runner = if options[:runner]
-                    force_runner(options[:runner])
+        @runner = if options[:command_runner]
+                    force_runner(options[:command_runner])
                   else
                     select_runner(options)
                   end
@@ -54,16 +54,16 @@ module Train::Transports
         end
       end
 
-      def force_runner(runner)
-        case runner
-        when 'generic'
+      def force_runner(command_runner)
+        case command_runner
+        when :generic
           GenericRunner.new(self, options)
-        when 'windows_pipe'
+        when :windows_pipe
           WindowsPipeRunner.new
-        when 'windows_shell'
+        when :windows_shell
           WindowsShellRunner.new
         else
-          fail "Runner type \'#{runner}\' not supported"
+          fail "Runner type `#{command_runner}` not supported"
         end
       end
 

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -68,14 +68,15 @@ module Train::Transports
       end
 
       def run_command_via_connection(cmd)
-        if defined?(@runner)
-          @runner.run_command(cmd)
-        else
-          # The initial commands to determine OS will be ran without a runner
-          res = Mixlib::ShellOut.new(cmd)
-          res.run_command
-          Local::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
-        end
+        # Use the runner if it is available
+        return @runner.run_command(cmd) if defined?(@runner)
+
+        # If we don't have a runner, such as at the beginning of setting up the
+        # transport and performing the first few steps of OS detection, fall
+        # back to shelling out.
+        res = Mixlib::ShellOut.new(cmd)
+        res.run_command
+        Local::CommandResult.new(res.stdout, res.stderr, res.exitstatus)
       rescue Errno::ENOENT => _
         CommandResult.new('', '', 1)
       end

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -62,6 +62,8 @@ module Train::Transports
           WindowsPipeRunner.new
         when 'windows_shell'
           WindowsShellRunner.new
+        else
+          fail "Runner type \'#{runner}\' not supported"
         end
       end
 

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -100,6 +100,11 @@ describe 'local transport' do
 
       Train::Transports::Local::Connection.new(runner: 'windows_shell')
     end
+
+    it 'throws a RuntimeError when an invalid runner type is passed' do
+      err = proc { Train::Transports::Local::Connection.new(runner: 'invalid') }
+      err.must_raise(RuntimeError, "Runner type 'invalid' not supported")
+    end
   end
 
   describe 'when running a local command' do

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -68,7 +68,7 @@ describe 'local transport' do
         .expects(:new)
         .never
 
-      Train::Transports::Local::Connection.new(runner: 'generic')
+      Train::Transports::Local::Connection.new(command_runner: :generic)
     end
 
     it 'can select the `WindowsPipeRunner`' do
@@ -83,7 +83,7 @@ describe 'local transport' do
         .expects(:new)
         .never
 
-      Train::Transports::Local::Connection.new(runner: 'windows_pipe')
+      Train::Transports::Local::Connection.new(command_runner: :windows_pipe)
     end
 
     it 'can select the `WindowsShellRunner`' do
@@ -98,12 +98,12 @@ describe 'local transport' do
       Train::Transports::Local::Connection::WindowsShellRunner
         .expects(:new)
 
-      Train::Transports::Local::Connection.new(runner: 'windows_shell')
+      Train::Transports::Local::Connection.new(command_runner: :windows_shell)
     end
 
     it 'throws a RuntimeError when an invalid runner type is passed' do
-      err = proc { Train::Transports::Local::Connection.new(runner: 'invalid') }
-      err.must_raise(RuntimeError, "Runner type 'invalid' not supported")
+      proc { Train::Transports::Local::Connection.new(command_runner: :nope ) }
+        .must_raise(RuntimeError, "Runner type `:nope` not supported")
     end
   end
 

--- a/test/unit/transports/local_test.rb
+++ b/test/unit/transports/local_test.rb
@@ -13,7 +13,7 @@ class TransportHelper
     plat.family_hierarchy = opts[:family_hierarchy]
     plat.add_platform_methods
     Train::Platforms::Detect.stubs(:scan).returns(plat)
-    @transport = Train::Transports::Local.new
+    @transport = Train::Transports::Local.new(user_opts)
   end
 end
 
@@ -53,6 +53,53 @@ describe 'local transport' do
   it 'provides a file_via_connection method' do
     methods = connection.class.private_instance_methods(false)
     methods.include?(:file_via_connection).must_equal true
+  end
+
+  describe 'when overriding runner selection' do
+    it 'can select the `GenericRunner`' do
+      Train::Transports::Local::Connection::GenericRunner
+        .expects(:new)
+
+      Train::Transports::Local::Connection::WindowsPipeRunner
+        .expects(:new)
+        .never
+
+      Train::Transports::Local::Connection::WindowsShellRunner
+        .expects(:new)
+        .never
+
+      Train::Transports::Local::Connection.new(runner: 'generic')
+    end
+
+    it 'can select the `WindowsPipeRunner`' do
+      Train::Transports::Local::Connection::GenericRunner
+        .expects(:new)
+        .never
+
+      Train::Transports::Local::Connection::WindowsPipeRunner
+        .expects(:new)
+
+      Train::Transports::Local::Connection::WindowsShellRunner
+        .expects(:new)
+        .never
+
+      Train::Transports::Local::Connection.new(runner: 'windows_pipe')
+    end
+
+    it 'can select the `WindowsShellRunner`' do
+      Train::Transports::Local::Connection::GenericRunner
+        .expects(:new)
+        .never
+
+      Train::Transports::Local::Connection::WindowsPipeRunner
+        .expects(:new)
+        .never
+
+      Train::Transports::Local::Connection::WindowsShellRunner
+        .expects(:new)
+
+      Train::Transports::Local::Connection.new(runner: 'windows_shell')
+    end
   end
 
   describe 'when running a local command' do


### PR DESCRIPTION
This allows for overriding the default runner selection. For example, when running InSpec unit tests via AppVeyor on Windows the mock file loads would create too many named pipe processes thus exhausting available resources.