### PR TITLE
Return platform name that is lower case and underscored

### DIFF
--- a/test/unit/platforms/platform_test.rb
+++ b/test/unit/platforms/platform_test.rb
@@ -34,13 +34,19 @@ describe 'platform' do
     plat.title.must_equal('The Best Mock')
   end
 
+  it 'clean init name' do
+    plat = mock_platform_family('Mo ck')
+    plat.name.must_equal('mo_ck')
+  end
+
   it 'set name and name override' do
     plat = mock_platform_family('mock')
     plat.name.must_equal('mock')
     plat[:name].must_equal('mock')
-    plat.platform[:name] = 'mock2020'
-    plat.name.must_equal('mock2020')
-    plat[:name].must_equal('mock2020')
+    plat.platform[:name] = 'Mock 2020'
+    plat.add_platform_methods
+    plat.name.must_equal('mock_2020')
+    plat[:name].must_equal('mock_2020')
   end
 
   it 'check families' do

--- a/test/windows/local_test.rb
+++ b/test/windows/local_test.rb
@@ -25,7 +25,7 @@ describe 'windows local command' do
 
   it 'verify os' do
     os = conn.os
-    os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
+    os[:name].must_equal 'windows_server_2012_r2_datacenter'
     os[:family].must_equal "windows"
     os[:release].must_equal '6.3.9600'
     os[:arch].must_equal 'x86_64'

--- a/test/windows/winrm_test.rb
+++ b/test/windows/winrm_test.rb
@@ -27,7 +27,7 @@ describe 'windows winrm command' do
 
   it 'verify os' do
     os = conn.os
-    os[:name].must_equal 'Windows Server 2012 R2 Datacenter'
+    os[:name].must_equal 'windows_server_2012_r2_datacenter'
     os[:family].must_equal 'windows'
     os[:release].must_equal '6.3.9600'
     os[:arch].must_equal 'x86_64'


### PR DESCRIPTION
Fixes #191
Fixes chef/inspec#1732

This change is a remake of https://github.com/chef/train/pull/192 with the updated platform work. This change sets platform names to always return downcase and underscored.

Signed-off-by: Jared Quick <jquick@chef.io>