### PR TITLE
Set mock transport to use the platform instance variable

### DIFF
--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -57,8 +57,6 @@ end
 
 class Train::Transports::Mock
   class Connection < BaseConnection
-    attr_reader :os
-
     def initialize(conf = nil)
       super(conf)
       mock_os
@@ -80,7 +78,7 @@ class Train::Transports::Mock
       platform.family_hierarchy = mock_os_hierarchy(platform).flatten
       platform.platform = value
       platform.add_platform_methods
-      @os = platform
+      @platform = platform
     end
 
     def mock_os_hierarchy(plat)

--- a/test/unit/transports/mock_test.rb
+++ b/test/unit/transports/mock_test.rb
@@ -83,6 +83,7 @@ describe 'mock transport' do
   describe 'when accessing a mocked os' do
     it 'has the default mock os faily set to mock' do
       connection.os[:name].must_equal 'mock'
+      connection.platform[:name].must_equal 'mock'
     end
 
     it 'sets the OS to the mocked value' do


### PR DESCRIPTION
Currently you cannot use the platform keyword when using the mock transport as it currently only overrides the os call. This change sets mock transport to override the platform accordingly so it can be accessed via os or platform.

I did test local master inspec tests with this also.

Signed-off-by: Jared Quick <jquick@chef.io>