### PR TITLE
Add the base platform to the platform hierarchy

### DIFF
--- a/lib/train/platforms/detect/scanner.rb
+++ b/lib/train/platforms/detect/scanner.rb
@@ -46,7 +46,10 @@ module Train::Platforms::Detect
 
         if plat.class == Train::Platforms::Platform
           @platform[:family] = parent.name
-          return plat if condition.empty? || check_condition(condition)
+          if condition.empty? || check_condition(condition)
+            @family_hierarchy << plat.name
+            return plat
+          end
         elsif plat.class == Train::Platforms::Family
           plat = scan_family_children(plat)
           return plat unless plat.nil?

--- a/test/unit/platforms/detect/scanner_test.rb
+++ b/test/unit/platforms/detect/scanner_test.rb
@@ -12,7 +12,7 @@ describe 'scanner' do
     it 'return child' do
       family = Train::Platforms.family('linux')
       scanner.scan_family_children(family).name.must_equal('linux')
-      scanner.instance_variable_get(:@family_hierarchy).must_equal(['linux'])
+      scanner.instance_variable_get(:@family_hierarchy).must_equal(['linux', 'linux'])
     end
 
     it 'return nil' do

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -29,6 +29,7 @@ describe 'os_detect' do
       platform[:name].must_equal('oracle')
       platform[:family].must_equal('redhat')
       platform[:release].must_equal('7')
+      platform.family_hierarchy.include?('oracle').must_equal true
     end
   end
 
@@ -91,6 +92,7 @@ describe 'os_detect' do
         platform[:name].must_equal('ubuntu')
         platform[:family].must_equal('debian')
         platform[:release].must_equal('16.04')
+        platform.family_hierarchy.include?('ubuntu').must_equal true
       end
     end
 


### PR DESCRIPTION
This is a small change that will add the base platform name to the family hierarchy. This change will be used upstream to allow InSpec "in_family?" call to be used with the platform name as well.

Signed-off-by: Jared Quick <jquick@chef.io>