### PR TITLE
Add AWS transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 [![Build Status Master](https://ci.appveyor.com/api/projects/status/github/chef/train?branch=master&svg=true&passingText=master%20-%20Ok&pendingText=master%20-%20Pending&failingText=master%20-%20Failing)](https://ci.appveyor.com/project/Chef/train/branch/master)
 [![Gem Version](https://badge.fury.io/rb/train.svg)](https://badge.fury.io/rb/train)
 
-Train lets you talk to your local or remote operating systems with a unified interface.
+Train lets you talk to your local or remote operating systems and APIs with a unified interface.
 
 It allows you to:
 
 * execute commands via `run_command`
 * interact with files via `file`
 * identify the target operating system via `os`
+* authenticate to API-based services and treat them like a platform
 
 Train supports:
 
@@ -19,6 +20,7 @@ Train supports:
 * WinRM
 * Docker
 * Mock (for testing and debugging)
+* AWS as an API
 
 # Examples
 
@@ -61,6 +63,21 @@ require 'train'
 train = Train.create('docker', host: 'container_id...')
 ```
 
+**AWS**
+
+To use AWS API authentication, setup an AWS client profile to store the Access Key ID and Secret Access Key.
+
+```ruby
+require 'train'
+train = Train.create('aws', region: 'us-east-2', profile: 'my-profile')
+```
+
+You may also use the standard AWS CLI environment variables, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION`.
+```ruby
+require 'train'
+train = Train.create('aws')
+```
+
 ## Configuration
 
 To get a list of available options for a plugin:
@@ -95,6 +112,10 @@ puts conn.os[:release]
 
 # access files
 puts conn.file('/proc/version').content
+
+# access specific API client functionality
+ec2_client = train.connection.aws_client(Aws::EC2::Client)
+puts ec2_client.describe_instances
 
 # close the connection
 conn.close

--- a/lib/train/platforms.rb
+++ b/lib/train/platforms.rb
@@ -6,6 +6,7 @@ require 'train/platforms/platform'
 require 'train/platforms/detect'
 require 'train/platforms/detect/scanner'
 require 'train/platforms/detect/specifications/os'
+require 'train/platforms/detect/specifications/api'
 
 module Train::Platforms
   class << self

--- a/lib/train/platforms/detect/specifications/api.rb
+++ b/lib/train/platforms/detect/specifications/api.rb
@@ -1,12 +1,4 @@
-
 # encoding: utf-8
-
-# rubocop:disable Style/Next
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/CyclomaticComplexity
-# rubocop:disable Metrics/ClassLength
-# rubocop:disable Metrics/MethodLength
-# rubocop:disable Metrics/PerceivedComplexity
 
 module Train::Platforms::Detect::Specifications
   class Api

--- a/lib/train/platforms/detect/specifications/api.rb
+++ b/lib/train/platforms/detect/specifications/api.rb
@@ -1,0 +1,21 @@
+
+# encoding: utf-8
+
+# rubocop:disable Style/Next
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/PerceivedComplexity
+
+module Train::Platforms::Detect::Specifications
+  class Api
+    def self.load
+      plat = Train::Platforms
+
+      plat.family('api')
+      plat.family('cloud').in_family('api')
+      plat.name('aws').in_family('cloud')
+    end
+  end
+end

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -23,6 +23,7 @@ class Train::Plugins::Transport
       @options = options || {}
       @logger = @options.delete(:logger) || Logger.new(STDOUT)
       Train::Platforms::Detect::Specifications::OS.load
+      Train::Platforms::Detect::Specifications::Api.load
 
       # default caching options
       @cache_enabled = {
@@ -74,6 +75,20 @@ class Train::Plugins::Transport
     # Is this a local transport?
     def local?
       false
+    end
+
+    def direct_platform(name)
+      plat = Train::Platforms.name(name)
+      plat.backend = self
+      plat.family_hierarchy = family_hierarchy(plat).flatten
+      plat
+    end
+
+    def family_hierarchy(plat)
+      plat.families.each_with_object([]) do |(k, _v), memo|
+        memo << k.name
+        memo << family_hierarchy(k) unless k.families.empty?
+      end
     end
 
     # Get information on the operating system which this transport connects to.

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -24,7 +24,7 @@ class Train::Plugins::Transport
       @logger = @options.delete(:logger) || Logger.new(STDOUT)
       Train::Platforms::Detect::Specifications::OS.load
       Train::Platforms::Detect::Specifications::Api.load
-      
+
       # default caching options
       @cache_enabled = {
         file: true,

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -24,7 +24,7 @@ class Train::Plugins::Transport
       @logger = @options.delete(:logger) || Logger.new(STDOUT)
       Train::Platforms::Detect::Specifications::OS.load
       Train::Platforms::Detect::Specifications::Api.load
-
+      
       # default caching options
       @cache_enabled = {
         file: true,

--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -1,0 +1,72 @@
+require 'train/plugins'
+require 'aws-sdk'
+
+module Train::Transports
+  class Aws < Train.plugin(1)
+    name 'aws'
+    option :region, required: true, default: ENV['AWS_REGION']
+    option :access_key_id, default: ENV['AWS_ACCESS_KEY_ID']
+    option :secret_access_key, default: ENV['AWS_SECRET_ACCESS_KEY']
+    option :session_token, default: ENV['AWS_SESSION_TOKEN']
+
+    # This can provide the access key id and secret access key
+    option :profile, default: ENV['AWS_PROFILE']
+
+    def connection(_ = nil)
+      @connection ||= Connection.new(@options)
+    end
+
+    class Connection < BaseConnection
+      def initialize(options)
+        # Override for any cli options
+        # aws://region/my-profile
+        options[:region] = options[:host] || options[:region]
+        if options[:path]
+          # string the leading / from path
+          options[:profile] = options[:path][1..-1]
+        end
+        super(options)
+
+        @cache_enabled[:api_call] = true
+        @cache[:api_call] = {}
+
+        connect
+      end
+
+      def platform
+        direct_platform('aws')
+      end
+
+      def aws_client(klass)
+        return klass.new unless cache_enabled?(:api_call)
+        @cache[:api_call][klass.to_s.to_sym] ||= klass.new
+      end
+
+      def aws_resource(klass, args)
+        klass.new(args)
+      end
+
+      def connect
+        if @options[:profile]
+          creds = ::Aws::SharedCredentials.new(profile_name: @options[:profile])
+        else
+          creds = ::Aws::Credentials.new(
+            @options[:access_key_id],
+            @options[:secret_access_key],
+            @options[:session_token],
+          )
+        end
+
+        opts = {
+          region: @options[:region],
+          credentials: creds,
+        }
+        ::Aws.config.update(opts)
+      end
+
+      def uri
+        "aws://#{@options[:region]}"
+      end
+    end
+  end
+end

--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -48,22 +48,8 @@ module Train::Transports
       end
 
       def connect
-        if @options[:profile]
-          creds = ::Aws::SharedCredentials.new(profile_name: @options[:profile])
-        else
-          creds = ::Aws::Credentials.new(
-            @options[:access_key_id],
-            @options[:secret_access_key],
-            @options[:session_token],
-          )
-        end
-
-        opts = { region: @options[:region] }
-
-        # fall back to the native aws credentials if we are not overriding
-        opts[:credentials] = creds unless creds.access_key_id.nil?
-
-        ::Aws.config.update(opts)
+        ENV['AWS_PROFILE'] = @options[:profile] if @options[:profile]
+        ENV['AWS_REGION'] = @options[:region] if @options[:region]
       end
 
       def uri

--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -58,10 +58,11 @@ module Train::Transports
           )
         end
 
-        opts = {
-          region: @options[:region],
-          credentials: creds,
-        }
+        opts = { region: @options[:region] }
+
+        # fall back to the native aws credentials if we are not overriding
+        opts[:credentials] = creds unless creds.access_key_id.nil?
+
         ::Aws.config.update(opts)
       end
 

--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'train/plugins'
 require 'aws-sdk'
 

--- a/lib/train/transports/mock.rb
+++ b/lib/train/transports/mock.rb
@@ -75,17 +75,10 @@ class Train::Transports::Mock
       value = { name: 'mock', family: 'mock', release: 'unknown', arch: 'unknown' }.merge(value)
 
       platform = Train::Platforms.name(value[:name])
-      platform.family_hierarchy = mock_os_hierarchy(platform).flatten
+      platform.family_hierarchy = family_hierarchy(platform).flatten
       platform.platform = value
       platform.add_platform_methods
       @platform = platform
-    end
-
-    def mock_os_hierarchy(plat)
-      plat.families.each_with_object([]) do |(k, _v), memo|
-        memo << k.name
-        memo << mock_os_hierarchy(k) unless k.families.empty?
-      end
     end
 
     def commands=(commands)

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -43,6 +43,18 @@ describe 'v1 Connection Plugin' do
                 .must_be_instance_of(Logger)
     end
 
+    it 'provides direct platform' do
+      plat = connection.direct_platform('linux')
+      plat.name.must_equal 'linux'
+      plat.family_hierarchy.must_equal ['linux', 'unix']
+    end
+
+    it 'provides family hierarchy' do
+      plat = Train::Platforms.name('linux')
+      family = connection.family_hierarchy(plat)
+      family.flatten.must_equal ['linux', 'unix']
+    end
+
     it 'must use the user-provided logger' do
       l = rand
       cls.new({logger: l})

--- a/test/unit/transports/aws_test.rb
+++ b/test/unit/transports/aws_test.rb
@@ -1,16 +1,16 @@
 # encoding: utf-8
 
-# envs have to be set before we start up the testing
-ENV['AWS_REGION'] = 'test_region'
-ENV['AWS_ACCESS_KEY_ID'] = 'test_key_id'
-ENV['AWS_SECRET_ACCESS_KEY'] = 'test_access_key'
-ENV['AWS_SESSION_TOKEN'] = 'test_session_token'
-
 require 'helper'
-require 'train/transports/aws'
 
 describe 'aws transport' do
   def transport(options = nil)
+    ENV['AWS_REGION'] = 'test_region'
+    ENV['AWS_ACCESS_KEY_ID'] = 'test_key_id'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'test_access_key'
+    ENV['AWS_SESSION_TOKEN'] = 'test_session_token'
+
+    # need to require this at here as it captures the envs on load
+    require 'train/transports/aws'
     Train::Transports::Aws.new(options)
   end
   let(:connection) { transport.connection }
@@ -82,20 +82,18 @@ describe 'aws transport' do
   end
 
   describe 'connect' do
-    it 'validate aws connection config' do
-      options[:profile] = nil
-      creds = connection.connect
-      creds[:credentials].access_key_id.must_equal 'test_key_id'
-      creds[:credentials].secret_access_key.must_equal 'test_access_key'
-      creds[:credentials].session_token.must_equal 'test_session_token'
-      creds[:region].must_equal 'test_region'
+    it 'validate aws connection with profile' do
+      options[:profile] = 'xyz'
+      ENV['AWS_PROFILE'].must_be_nil
+      connection.connect
+      ENV['AWS_PROFILE'].must_equal 'xyz'
     end
 
-    it 'validate aws connection fallback' do
-      options[:profile] = nil
-      options[:access_key_id] = nil
-
-      Aws.config.expects(:update).never
+    it 'validate aws connection with region' do
+      options[:region] = 'xyz'
+      ENV['AWS_REGION'].must_equal 'test_region'
+      connection.connect
+      ENV['AWS_REGION'].must_equal 'xyz'
     end
   end
 end

--- a/test/unit/transports/aws_test.rb
+++ b/test/unit/transports/aws_test.rb
@@ -90,5 +90,12 @@ describe 'aws transport' do
       creds[:credentials].session_token.must_equal 'test_session_token'
       creds[:region].must_equal 'test_region'
     end
+
+    it 'validate aws connection fallback' do
+      options[:profile] = nil
+      options[:access_key_id] = nil
+
+      Aws.config.expects(:update).never
+    end
   end
 end

--- a/test/unit/transports/aws_test.rb
+++ b/test/unit/transports/aws_test.rb
@@ -1,0 +1,94 @@
+# encoding: utf-8
+
+# envs have to be set before we start up the testing
+ENV['AWS_REGION'] = 'test_region'
+ENV['AWS_ACCESS_KEY_ID'] = 'test_key_id'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'test_access_key'
+ENV['AWS_SESSION_TOKEN'] = 'test_session_token'
+
+require 'helper'
+require 'train/transports/aws'
+
+describe 'aws transport' do
+  def transport(options = nil)
+    Train::Transports::Aws.new(options)
+  end
+  let(:connection) { transport.connection }
+  let(:options) { connection.instance_variable_get(:@options) }
+  let(:cache) { connection.instance_variable_get(:@cache) }
+
+  describe 'options' do
+    it 'defaults to env options' do
+      options[:region].must_equal 'test_region'
+      options[:access_key_id].must_equal 'test_key_id'
+      options[:secret_access_key].must_equal 'test_access_key'
+      options[:session_token].must_equal 'test_session_token'
+    end
+
+    it 'test options override' do
+      transport = transport(region: 'us-east-2', access_key_id: '8')
+      options = transport.connection.instance_variable_get(:@options)
+      options[:region].must_equal 'us-east-2'
+      options[:access_key_id].must_equal '8'
+      options[:secret_access_key].must_equal 'test_access_key'
+      options[:session_token].must_equal 'test_session_token'
+    end
+
+    it 'test url parse override' do
+      transport = transport(host: 'us-east-2')
+      options = transport.connection.instance_variable_get(:@options)
+      options[:region].must_equal 'us-east-2'
+      options[:session_token].must_equal 'test_session_token'
+    end
+  end
+
+  describe 'platform' do
+    it 'returns platform' do
+      plat = connection.platform
+      plat.name.must_equal 'aws'
+      plat.family_hierarchy.must_equal ['cloud', 'api']
+    end
+  end
+
+  describe 'aws_client' do
+    it 'test aws_client with caching' do
+      client = connection.aws_client(Object)
+      client.is_a?(Object).must_equal true
+      cache[:api_call].count.must_equal 1
+    end
+
+    it 'test aws_client without caching' do
+      connection.disable_cache(:api_call)
+      client = connection.aws_client(Object)
+      client.is_a?(Object).must_equal true
+      cache[:api_call].count.must_equal 0
+    end
+  end
+
+  describe 'aws_resource' do
+    class AwsResource
+      attr_reader :hash
+      def initialize(hash)
+        @hash = hash
+      end
+    end
+
+    it 'test aws_resource with arguments' do
+      hash = { user: 1, name: 'test_user' }
+      resource = connection.aws_resource(AwsResource, hash)
+      resource.hash.must_equal hash
+      cache[:api_call].count.must_equal 0
+    end
+  end
+
+  describe 'connect' do
+    it 'validate aws connection config' do
+      options[:profile] = nil
+      creds = connection.connect
+      creds[:credentials].access_key_id.must_equal 'test_key_id'
+      creds[:credentials].secret_access_key.must_equal 'test_access_key'
+      creds[:credentials].session_token.must_equal 'test_session_token'
+      creds[:region].must_equal 'test_region'
+    end
+  end
+end

--- a/train.gemspec
+++ b/train.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'winrm', '~> 2.0'
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'
+  spec.add_dependency 'aws-sdk', '~> 2'
 
   spec.add_development_dependency 'mocha', '~> 1.1'
 end


### PR DESCRIPTION
Adds a new type of platform, the `api` type.  AWS is added as a transport.  Reads credentials information from the constructor, from environment variables, or (when used from Inspec) via a URL.

URL format:
```
aws://     # Read AWS_REGION and AWS_PROFILE from env vars
aws://us-east-2  # Read AWS_PROFILE from env var
aws://us-east-2/my-profile   # Explicit.
```

Train users may access AWS client objects via `train.connection.aws_client(Aws::EC2::Client)` (for example).  The connection objects are cached, but their API call results are not.

Closes #229 .