### PR TITLE
if ssh closes the session force it to reset and reopen

### DIFF
--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -182,6 +182,7 @@ class Train::Transports::SSH
       cmd.dup.force_encoding('binary') if cmd.respond_to?(:force_encoding)
       logger.debug("[SSH] #{self} (#{cmd})")
 
+      reset_session if session.closed?
       session.open_channel do |channel|
         # wrap commands if that is configured
         cmd = @cmd_wrapper.run(cmd) unless @cmd_wrapper.nil?
@@ -230,6 +231,10 @@ class Train::Transports::SSH
         retries: @connection_retries.to_i,
         delay:   @connection_retry_sleep.to_i,
       }.merge(retry_options))
+    end
+
+    def reset_session()
+      @session = nil
     end
 
     # String representation of object, reporting its connection details and

--- a/lib/train/transports/ssh_connection.rb
+++ b/lib/train/transports/ssh_connection.rb
@@ -233,7 +233,7 @@ class Train::Transports::SSH
       }.merge(retry_options))
     end
 
-    def reset_session()
+    def reset_session
       @session = nil
     end
 


### PR DESCRIPTION
I saw this happen today with some old cisco devices. It was not a timeout issue but rather the connection closing after each command. While this behavior can be improved it's also dangerous to go nose-diving if a connection is already closed. Rather reset and try again.

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>