### PR TITLE
Fix AIX and QNX file support

### DIFF
--- a/lib/train/file.rb
+++ b/lib/train/file.rb
@@ -4,13 +4,7 @@
 # author: Dominik Richter
 
 require 'train/file/local'
-require 'train/file/local/unix'
-require 'train/file/local/windows'
 require 'train/file/remote'
-require 'train/file/remote/unix'
-require 'train/file/remote/linux'
-require 'train/file/remote/windows'
-require 'train/file/remote/qnx'
 require 'digest/sha2'
 require 'digest/md5'
 require 'train/extras/stat'

--- a/lib/train/file/local.rb
+++ b/lib/train/file/local.rb
@@ -68,3 +68,8 @@ module Train
     end
   end
 end
+
+# subclass requires are loaded after Train::File::Local is defined
+# to avoid superclass mismatch errors
+require 'train/file/local/unix'
+require 'train/file/local/windows'

--- a/lib/train/file/remote.rb
+++ b/lib/train/file/remote.rb
@@ -26,3 +26,11 @@ module Train
     end
   end
 end
+
+# subclass requires are loaded after Train::File::Remote is defined
+# to avoid superclass mismatch errors
+require 'train/file/remote/aix'
+require 'train/file/remote/linux'
+require 'train/file/remote/qnx'
+require 'train/file/remote/unix'
+require 'train/file/remote/windows'

--- a/lib/train/file/remote/qnx.rb
+++ b/lib/train/file/remote/qnx.rb
@@ -8,7 +8,7 @@ require 'train/file/remote/unix'
 module Train
   class File
     class Remote
-      class Aix < Train::File::Remote::Unix
+      class Qnx < Train::File::Remote::Unix
         def content
           cat = 'cat'
           cat = '/proc/boot/cat' if @backend.os[:release].to_i >= 7
@@ -32,7 +32,7 @@ module Train
           mode owner group uid gid mtime size selinux_label link_path mounted stat
         }.each do |field|
           define_method field.to_sym do
-            fail NotImplementedError, "QNX does not implement the #{m}() method yet."
+            fail NotImplementedError, "QNX does not implement the #{field}() method yet."
           end
         end
       end

--- a/test/unit/file/remote/aix_test.rb
+++ b/test/unit/file/remote/aix_test.rb
@@ -1,0 +1,26 @@
+require 'helper'
+require 'train/transports/local'
+require 'train/file/remote/aix'
+require 'train/transports/mock'
+
+describe Train::File::Remote::Aix do
+  let(:cls) { Train::File::Remote::Aix }
+  let(:backend) {
+    backend = Train::Transports::Mock.new.connection
+    backend.mock_os({ name: 'aix', family: 'unix' })
+    backend
+  }
+
+  it 'returns a nil link_path if the object is not a symlink' do
+    file = cls.new(backend, 'path')
+    file.stubs(:symlink?).returns(false)
+    file.link_path.must_be_nil
+  end
+
+  it 'returns a correct link_path' do
+    file = cls.new(backend, 'path')
+    file.stubs(:symlink?).returns(true)
+    backend.mock_command("perl -e 'print readlink shift' path", 'our_link_path')
+    file.link_path.must_equal 'our_link_path'
+  end
+end

--- a/test/unit/file/remote/qnx_test.rb
+++ b/test/unit/file/remote/qnx_test.rb
@@ -1,0 +1,44 @@
+require 'helper'
+require 'train/transports/local'
+require 'train/file/remote/qnx'
+require 'train/transports/mock'
+
+describe Train::File::Remote::Qnx do
+  let(:cls) { Train::File::Remote::Qnx }
+  let(:backend) {
+    backend = Train::Transports::Mock.new.connection
+    backend.mock_os({ name: 'qnx', family: 'unix' })
+    backend
+  }
+
+  it 'returns file contents when the file exists' do
+    out = rand.to_s
+    backend.mock_command('cat path', out)
+    file = cls.new(backend, 'path')
+    file.stubs(:exist?).returns(true)
+    file.content.must_equal out
+  end
+
+  it 'returns nil contents when the file does not exist' do
+    file = cls.new(backend, 'path')
+    file.stubs(:exist?).returns(false)
+    file.content.must_be_nil
+  end
+
+  it 'returns a file type' do
+    backend.mock_command('file path', 'blah directory blah')
+    cls.new(backend, 'path').type.must_equal :directory
+  end
+
+  it 'returns a directory type' do
+    backend.mock_command('file path', 'blah regular file blah')
+    cls.new(backend, 'path').type.must_equal :file
+  end
+
+  it 'raises exception for unimplemented methods' do
+    file = cls.new(backend, 'path')
+    %w{mode owner group uid gid mtime size selinux_label link_path mounted stat}.each do |m|
+      proc { file.send(m) }.must_raise NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
During the file refactor in #193, an error was made in class names that caused AIX file operations to be severely limited and QNX file support was broken.

This restores the AIX and QNX remote file functionality and adds unit tests for each of those classes.

Supersedes #244