### PR TITLE
Add azure transport

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,5 @@ Style/IfUnlessModifier:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+SignalException:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'rake', '~> 10'
   gem 'rubocop', '~> 0.36.0'
   gem 'simplecov', '~> 0.10'
-  gem 'concurrent-ruby', '~> 0.9'
+  gem 'concurrent-ruby', '~> 1.0'
 end
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Train supports:
 * Docker
 * Mock (for testing and debugging)
 * AWS as an API
+* Azure as an API
 
 # Examples
 

--- a/lib/train/platforms/detect/specifications/api.rb
+++ b/lib/train/platforms/detect/specifications/api.rb
@@ -6,8 +6,10 @@ module Train::Platforms::Detect::Specifications
       plat = Train::Platforms
 
       plat.family('api')
+
       plat.family('cloud').in_family('api')
       plat.name('aws').in_family('cloud')
+      plat.name('azure').in_family('cloud')
     end
   end
 end

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -116,7 +116,7 @@ module Train::Transports
       private
 
       def parse_credentials_file # rubocop:disable Metrics/AbcSize
-        # If an INSPEC_AZURE_CREDS environment has been specified set the
+        # If an AZURE_CRED_FILE environment variable has been specified set the
         # the credentials file to that, otherwise set the one in home
         azure_creds_file = @options[:credentials_file]
         azure_creds_file = File.join(Dir.home, '.azure', 'credentials') if azure_creds_file.nil?

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -76,7 +76,7 @@ module Train::Transports
         return unless File.readable?(azure_creds_file)
 
         credentials = IniFile.load(File.expand_path(azure_creds_file))
-        if !@options[:subscription_id].nil?
+        if @options[:subscription_id]
           id = @options[:subscription_id]
         elsif !ENV['AZURE_SUBSCRIPTION_NUMBER'].nil?
           subscription_number = ENV['AZURE_SUBSCRIPTION_NUMBER'].to_i

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -1,0 +1,108 @@
+# encoding: utf-8
+
+require 'train/plugins'
+require 'ms_rest_azure'
+require 'azure_mgmt_resources'
+require 'inifile'
+
+module Train::Transports
+  class Azure < Train.plugin(1)
+    name 'azure'
+    option :tenant_id, default: ENV['AZURE_TENANT_ID']
+    option :client_id, default: ENV['AZURE_CLIENT_ID']
+    option :client_secret, default: ENV['AZURE_CLIENT_SECRET']
+    option :subscription_id, default: ENV['AZURE_SUBSCRIPTION_ID']
+
+    # This can provide the client id and secret
+    option :credentials_file, required: true, default: ENV['AZURE_CRED_FILE']
+
+    def connection(_ = nil)
+      @connection ||= Connection.new(@options)
+    end
+
+    class Connection < BaseConnection
+      def initialize(options)
+        # Override for any cli options
+        # azure://subscription_id
+        options[:subscription_id] = options[:host] || options[:subscription_id]
+        super(options)
+
+        @cache_enabled[:api_call] = true
+        @cache[:api_call] = {}
+
+        if @options[:client_secret].nil? && @options[:client_id].nil?
+          parse_credentials_file
+        end
+        connect
+      end
+
+      def platform
+        direct_platform('azure')
+      end
+
+      def azure_client(klass = nil)
+        # return the managment client by default
+        klass = ::Azure::Resources::Profiles::Latest::Mgmt::Client if klass.nil?
+        return klass.new(@credentials) unless cache_enabled?(:api_call)
+
+        @cache[:api_call][klass.to_s.to_sym] ||= klass.new(@credentials)
+      end
+
+      def connect
+        provider = ::MsRestAzure::ApplicationTokenProvider.new(
+          @options[:tenant_id],
+          @options[:client_id],
+          @options[:client_secret],
+        )
+
+        @credentials = {
+          credentials: ::MsRest::TokenCredentials.new(provider),
+          subscription_id: @options[:subscription_id],
+          tenant_id: @options[:tenant_id],
+          client_id: @options[:client_id],
+          client_secret: @options[:client_secret],
+        }
+      end
+
+      def uri
+        "azure://#{@options[:subscription_id]}"
+      end
+
+      private
+
+      def parse_credentials_file # rubocop:disable Metrics/AbcSize
+        # If an INSPEC_AZURE_CREDS environment has been specified set the
+        # the credentials file to that, otherwise set the one in home
+        azure_creds_file = @options[:credentials_file]
+        azure_creds_file = File.join(Dir.home, '.azure', 'credentials') if azure_creds_file.nil?
+        return unless File.file?(azure_creds_file)
+
+        credentials = IniFile.load(File.expand_path(azure_creds_file))
+        if !@options[:subscription_id].nil?
+          id = @options[:subscription_id]
+        elsif !ENV['AZURE_SUBSCRIPTION_NUMBER'].nil?
+          subscription_number = ENV['AZURE_SUBSCRIPTION_NUMBER'].to_i
+
+          # Check that the specified index is not greater than the number of subscriptions
+          if subscription_number > credentials.sections.length
+            raise format(
+              'Your credentials file only contains %s subscriptions.  You specified number %s.',
+              @credentials.sections.length,
+              subscription_number,
+            )
+          end
+          id = credentials.sections[subscription_number - 1]
+        else
+          raise 'Multiple credentials detected, please set a subscription id to use.' if credentials.sections.count > 1
+          id = credentials.sections[0]
+        end
+
+        raise format('No credentials found for subscription number %s', id) if credentials.sections.empty? || credentials[id].empty?
+        @options[:subscription_id] = id
+        @options[:tenant_id] = credentials[id]['tenant_id']
+        @options[:client_id] = credentials[id]['client_id']
+        @options[:client_secret] = credentials[id]['client_secret']
+      end
+    end
+  end
+end

--- a/test/unit/transports/azure_test.rb
+++ b/test/unit/transports/azure_test.rb
@@ -26,7 +26,7 @@ describe 'azure transport' do
       options[:subscription_id].must_equal 'test_subscription_id'
     end
 
-    it 'test options override' do
+    it 'allows for options override' do
       transport = transport(subscription_id: '102', client_id: '717')
       options = transport.connection.instance_variable_get(:@options)
       options[:tenant_id].must_equal 'test_tenant_id'
@@ -35,7 +35,7 @@ describe 'azure transport' do
       options[:subscription_id].must_equal '102'
     end
 
-    it 'test url parse override' do
+    it 'allows uri parse override' do
       transport = transport(host: '999')
       options = transport.connection.instance_variable_get(:@options)
       options[:tenant_id].must_equal 'test_tenant_id'
@@ -58,14 +58,15 @@ describe 'azure transport' do
         @hash = hash
       end
     end
-    it 'test azure_client with caching' do
+
+    it 'can use azure_client with caching' do
       connection.instance_variable_set(:@credentials, {})
       client = connection.azure_client(AzureResource)
       client.is_a?(AzureResource).must_equal true
       cache[:api_call].count.must_equal 1
     end
 
-    it 'test azure_client without caching' do
+    it 'can use azure_client without caching' do
       connection.instance_variable_set(:@credentials, {})
       connection.disable_cache(:api_call)
       client = connection.azure_client(AzureResource)
@@ -73,7 +74,7 @@ describe 'azure transport' do
       cache[:api_call].count.must_equal 0
     end
 
-    it 'test azure_client default client' do
+    it 'can use azure_client default client' do
       client = connection.azure_client
       client.class.must_equal Azure::Resources::Profiles::Latest::Mgmt::Client
     end
@@ -109,6 +110,7 @@ describe 'azure transport' do
       file.close
       file
     end
+
     it 'validate credentials from file' do
       options[:credentials_file] = cred_file.path
       options[:subscription_id] = 'my_subscription_id'

--- a/test/unit/transports/azure_test.rb
+++ b/test/unit/transports/azure_test.rb
@@ -1,0 +1,146 @@
+# encoding: utf-8
+
+require 'helper'
+
+describe 'azure transport' do
+  def transport(options = nil)
+    ENV['AZURE_TENANT_ID'] = 'test_tenant_id'
+    ENV['AZURE_CLIENT_ID'] = 'test_client_id'
+    ENV['AZURE_CLIENT_SECRET'] = 'test_client_secret'
+    ENV['AZURE_SUBSCRIPTION_ID'] = 'test_subscription_id'
+
+    # need to require this at here as it captures the envs on load
+    require 'train/transports/azure'
+    Train::Transports::Azure.new(options)
+  end
+  let(:connection) { transport.connection }
+  let(:options) { connection.instance_variable_get(:@options) }
+  let(:cache) { connection.instance_variable_get(:@cache) }
+  let(:credentials) { connection.instance_variable_get(:@credentials) }
+
+  describe 'options' do
+    it 'defaults to env options' do
+      options[:tenant_id].must_equal 'test_tenant_id'
+      options[:client_id].must_equal 'test_client_id'
+      options[:client_secret].must_equal 'test_client_secret'
+      options[:subscription_id].must_equal 'test_subscription_id'
+    end
+
+    it 'test options override' do
+      transport = transport(subscription_id: '102', client_id: '717')
+      options = transport.connection.instance_variable_get(:@options)
+      options[:tenant_id].must_equal 'test_tenant_id'
+      options[:client_id].must_equal '717'
+      options[:client_secret].must_equal 'test_client_secret'
+      options[:subscription_id].must_equal '102'
+    end
+
+    it 'test url parse override' do
+      transport = transport(host: '999')
+      options = transport.connection.instance_variable_get(:@options)
+      options[:tenant_id].must_equal 'test_tenant_id'
+      options[:subscription_id].must_equal '999'
+    end
+  end
+
+  describe 'platform' do
+    it 'returns platform' do
+      plat = connection.platform
+      plat.name.must_equal 'azure'
+      plat.family_hierarchy.must_equal ['cloud', 'api']
+    end
+  end
+
+  describe 'azure_client' do
+    class AzureResource
+      attr_reader :hash
+      def initialize(hash)
+        @hash = hash
+      end
+    end
+    it 'test azure_client with caching' do
+      connection.instance_variable_set(:@credentials, {})
+      client = connection.azure_client(AzureResource)
+      client.is_a?(AzureResource).must_equal true
+      cache[:api_call].count.must_equal 1
+    end
+
+    it 'test azure_client without caching' do
+      connection.instance_variable_set(:@credentials, {})
+      connection.disable_cache(:api_call)
+      client = connection.azure_client(AzureResource)
+      client.is_a?(AzureResource).must_equal true
+      cache[:api_call].count.must_equal 0
+    end
+
+    it 'test azure_client default client' do
+      client = connection.azure_client
+      client.class.must_equal Azure::Resources::Profiles::Latest::Mgmt::Client
+    end
+  end
+
+  describe 'connect' do
+    it 'validate credentials' do
+      connection.connect
+      credentials[:credentials].class.must_equal MsRest::TokenCredentials
+      credentials[:tenant_id].must_equal 'test_tenant_id'
+      credentials[:client_id].must_equal 'test_client_id'
+      credentials[:client_secret].must_equal 'test_client_secret'
+      credentials[:subscription_id].must_equal 'test_subscription_id'
+    end
+  end
+
+  describe 'parse_credentials_file' do
+    let(:cred_file) do
+      require 'tempfile'
+      file = Tempfile.new('cred_file')
+      info = <<-INFO
+        [my_subscription_id]
+        client_id = "my_client_id"
+        client_secret = "my_client_secret"
+        tenant_id = "my_tenant_id"
+
+        [my_subscription_id2]
+        client_id = "my_client_id2"
+        client_secret = "my_client_secret2"
+        tenant_id = "my_tenant_id2"
+      INFO
+      file.write(info)
+      file.close
+      file
+    end
+    it 'validate credentials from file' do
+      options[:credentials_file] = cred_file.path
+      options[:subscription_id] = 'my_subscription_id'
+      connection.send(:parse_credentials_file)
+
+      options[:tenant_id].must_equal 'my_tenant_id'
+      options[:client_id].must_equal 'my_client_id'
+      options[:client_secret].must_equal 'my_client_secret'
+      options[:subscription_id].must_equal 'my_subscription_id'
+    end
+
+    it 'validate credentials from file subscription override' do
+      options[:credentials_file] = cred_file.path
+      options[:subscription_id] = 'my_subscription_id2'
+      connection.send(:parse_credentials_file)
+
+      options[:tenant_id].must_equal 'my_tenant_id2'
+      options[:client_id].must_equal 'my_client_id2'
+      options[:client_secret].must_equal 'my_client_secret2'
+      options[:subscription_id].must_equal 'my_subscription_id2'
+    end
+
+    it 'validate credentials from file subscription index' do
+      options[:credentials_file] = cred_file.path
+      options[:subscription_id] = nil
+      ENV['AZURE_SUBSCRIPTION_NUMBER'] = '2'
+      connection.send(:parse_credentials_file)
+
+      options[:tenant_id].must_equal 'my_tenant_id2'
+      options[:client_id].must_equal 'my_client_id2'
+      options[:client_secret].must_equal 'my_client_secret2'
+      options[:subscription_id].must_equal 'my_subscription_id2'
+    end
+  end
+end

--- a/train.gemspec
+++ b/train.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'winrm-fs', '~> 1.0'
   spec.add_dependency 'docker-api', '~> 1.26'
   spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'azure_mgmt_resources', '~> 0.15'
+  spec.add_dependency 'inifile'
 
   spec.add_development_dependency 'mocha', '~> 1.1'
 end


### PR DESCRIPTION
Fixes https://github.com/chef/train/issues/233

Adds the azure transport and credential parsing. Heavily based off https://github.com/chef/inspec-azure/blob/master/libraries/azure_backend.rb

Signed-off-by: Jared Quick <jquick@chef.io>