### PR TITLE
Add qnx platform support

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -453,6 +453,19 @@ module Train::Platforms::Detect::Specifications
             true
           }
 
+      # qnx
+      plat.family('qnx').in_family('unix')
+          .detect {
+            true if unix_uname_s =~ /qnx/i
+          }
+      plat.name('qnx').title('QNX').in_family('qnx')
+          .detect {
+            @platform[:name] = unix_uname_s.lines[0].chomp.downcase
+            @platform[:release] = unix_uname_r.lines[0].chomp
+            @platform[:arch] = unix_uname_m
+            true
+          }
+
       # bsd family
       plat.family('bsd').in_family('unix')
           .detect {

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -183,6 +183,16 @@ describe 'os_detect' do
     end
   end
 
+  describe 'qnx' do
+    it 'sets the correct info for qnx platform' do
+      platform = scan_with_files('qnx', {})
+
+      platform[:name].must_equal('qnx')
+      platform[:family].must_equal('qnx')
+      platform[:release].must_equal('test-release')
+    end
+  end
+
   describe 'cisco' do
     it 'recognizes Cisco IOS12' do
       mock = Train::Transports::Mock::Connection.new


### PR DESCRIPTION
During the platform migration it seems QNX detect was not included. This PR adds back basic QNX support for train so its not resolving as unix.

Signed-off-by: Jared Quick <jquick@chef.io>