### PR TITLE
Support for Brocade FOS-based SAN devices

### DIFF
--- a/lib/train/platforms/detect/helpers/os_common.rb
+++ b/lib/train/platforms/detect/helpers/os_common.rb
@@ -53,6 +53,18 @@ module Train::Platforms::Detect::Helpers
       @uname[:m] = command_output('uname -m')
     end
 
+    def brocade_version
+      return @cache[:brocade] if @cache.key?(:brocade)
+      res = command_output('version')
+
+      m = res.match(/^Fabric OS:\s+v(\S+)$/)
+      unless m.nil?
+        return @cache[:brocade] = { version: m[1], type: 'fos' }
+      end
+
+      @cache[:brocade] = nil
+    end
+
     def cisco_show_version
       return @cache[:cisco] if @cache.key?(:cisco)
       res = command_output('show version')

--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -288,6 +288,13 @@ module Train::Platforms::Detect::Specifications
             end
           }
 
+      # brocade family detected here if device responds to 'uname' command,
+      # happens when logging in as root
+      plat.family('brocade').title('Brocade Family').in_family('linux')
+          .detect {
+            !brocade_version.nil?
+          }
+
       # genaric linux
       # this should always be last in the linux family list
       plat.name('linux').title('Genaric Linux').in_family('linux')
@@ -533,6 +540,21 @@ module Train::Platforms::Detect::Specifications
           .detect {
             v = cisco_show_version
             next unless v[:type] == 'nexus'
+            @platform[:release] = v[:version]
+            @platform[:arch] = nil
+            true
+          }
+
+      # brocade family
+      plat.family('brocade').title('Brocade Family').in_family('os')
+          .detect {
+            !brocade_version.nil?
+          }
+
+      plat.name('brocade_fos').title('Brocade FOS').in_family('brocade')
+          .detect {
+            v = brocade_version
+            next unless v[:type] == 'fos'
             @platform[:release] = v[:version]
             @platform[:arch] = nil
             true

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -224,4 +224,16 @@ describe 'os_detect' do
       platform[:release].must_equal('5.2')
     end
   end
+
+  describe 'brocade' do
+    it 'recognizes Brocade FOS-based SAN switches' do
+      mock = Train::Transports::Mock::Connection.new
+      mock.mock_command('version', "Kernel:     2.6.14.2\nFabric OS:  v7.4.2a\nMade on:    Thu Jun 29 19:22:14 2017\nFlash:      Sat Sep 9 17:30:42 2017\nBootProm:   1.0.11")
+      platform = Train::Platforms::Detect.scan(mock)
+
+      platform[:name].must_equal('brocade_fos')
+      platform[:family].must_equal('brocade')
+      platform[:release].must_equal('7.4.2a')
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I made a few changes that makes train able to detect FOS (Fabric OS) of Brocade Fibre-Channel switches.

The whole thing has currently a problem (stated in the code as well): The OS of these devices is linux based and does respond to `uname` command correctly when logging in as root user. If you log in with root, train will detect _Unix/Linux/Generic Linux_ what is not what we want here. If you log in with a different (normal) user, that user will get rbash shell as CLI and `uname` command is not available what makes it possible to "fall through" the unix detection and detect a brocade_fos platform.

Normally you won't log in using root user to those devices (vendor says it's not supported), nevertheless you could do this and it would break the detection. 

One workaround would be to handle brocade detection before unix, but that would cause `version` command run on all systems (except windows). I guess this is not really an option. Unfortunately I have no idea how to get around this problem currently.

Thanks for your feedback!