### PR TITLE
Add plat helper methods to api direct platforms.

### DIFF
--- a/lib/train/platforms/detect/scanner.rb
+++ b/lib/train/platforms/detect/scanner.rb
@@ -46,7 +46,6 @@ module Train::Platforms::Detect
         next unless instance_eval(&plat.detect) == true
 
         if plat.class == Train::Platforms::Platform
-          @platform[:family] = parent.name
           return plat if condition.empty? || check_condition(condition)
         elsif plat.class == Train::Platforms::Family
           plat = scan_family_children(plat)

--- a/lib/train/platforms/platform.rb
+++ b/lib/train/platforms/platform.rb
@@ -22,6 +22,10 @@ module Train::Platforms
       @families.collect { |k, _v| k.name }
     end
 
+    def family
+      @platform[:family] || @family_hierarchy[0]
+    end
+
     def name
       # Override here incase a updated name was set
       # during the detect logic

--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -81,6 +81,7 @@ class Train::Plugins::Transport
       plat = Train::Platforms.name(name)
       plat.backend = self
       plat.family_hierarchy = family_hierarchy(plat).flatten
+      plat.add_platform_methods
       plat
     end
 

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -44,9 +44,22 @@ describe 'v1 Connection Plugin' do
     end
 
     it 'provides direct platform' do
-      plat = connection.direct_platform('linux')
-      plat.name.must_equal 'linux'
-      plat.family_hierarchy.must_equal ['linux', 'unix']
+      plat = connection.direct_platform('mac_os_x')
+      plat.name.must_equal 'mac_os_x'
+      plat.linux?.must_equal false
+      plat.cloud?.must_equal false
+      plat.unix?.must_equal true
+      plat.family.must_equal 'darwin'
+      plat.family_hierarchy.must_equal ['darwin', 'bsd', 'unix']
+    end
+
+    it 'provides api direct platform' do
+      plat = connection.direct_platform('aws')
+      plat.name.must_equal 'aws'
+      plat.linux?.must_equal false
+      plat.cloud?.must_equal true
+      plat.family.must_equal 'cloud'
+      plat.family_hierarchy.must_equal ['cloud', 'api']
     end
 
     it 'provides family hierarchy' do


### PR DESCRIPTION
Add in the family method for api calls and grant them the normal helper methods (linux?, api?)

Signed-off-by: Jared Quick <jquick@chef.io>