### PR TITLE
Add api sdk versions as platform release

### DIFF
--- a/lib/train/plugins/base_connection.rb
+++ b/lib/train/plugins/base_connection.rb
@@ -77,9 +77,10 @@ class Train::Plugins::Transport
       false
     end
 
-    def direct_platform(name)
+    def direct_platform(name, platform_details = nil)
       plat = Train::Platforms.name(name)
       plat.backend = self
+      plat.platform = platform_details unless platform_details.nil?
       plat.family_hierarchy = family_hierarchy(plat).flatten
       plat.add_platform_methods
       plat

--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -31,11 +31,14 @@ module Train::Transports
         @cache_enabled[:api_call] = true
         @cache[:api_call] = {}
 
+        # additional platform details
+        @platform_details = { release: '2.0' }
+
         connect
       end
 
       def platform
-        direct_platform('aws')
+        direct_platform('aws', @platform_details)
       end
 
       def aws_client(klass)

--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -32,7 +32,8 @@ module Train::Transports
         @cache[:api_call] = {}
 
         # additional platform details
-        @platform_details = { release: '2.0' }
+        release = Gem.loaded_specs['aws-sdk'].version
+        @platform_details = { release: "aws-sdk-v#{release}" }
 
         connect
       end

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -37,7 +37,8 @@ module Train::Transports
         end
 
         # additional platform details
-        @platform_details = { release: '0.15' }
+        release = Gem.loaded_specs['azure_mgmt_resources'].version
+        @platform_details = { release: "azure_mgmt_resources-v#{release}" }
 
         connect
       end

--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -35,11 +35,15 @@ module Train::Transports
         if @options[:client_secret].nil? && @options[:client_id].nil?
           parse_credentials_file
         end
+
+        # additional platform details
+        @platform_details = { release: '0.15' }
+
         connect
       end
 
       def platform
-        direct_platform('azure')
+        direct_platform('azure', @platform_details)
       end
 
       def azure_client(klass = ::Azure::Resources::Profiles::Latest::Mgmt::Client)

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -62,6 +62,14 @@ describe 'v1 Connection Plugin' do
       plat.family_hierarchy.must_equal ['cloud', 'api']
     end
 
+    it 'provides api direct platform with platform options' do
+      details = { release: '2.0' }
+      plat = connection.direct_platform('aws', details)
+      plat.name.must_equal 'aws'
+      plat.release.must_equal '2.0'
+      plat[:release].must_equal '2.0'
+    end
+
     it 'provides family hierarchy' do
       plat = Train::Platforms.name('linux')
       family = connection.family_hierarchy(plat)

--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -63,11 +63,13 @@ describe 'v1 Connection Plugin' do
     end
 
     it 'provides api direct platform with platform options' do
-      details = { release: '2.0' }
+      aws_version = Gem.loaded_specs['aws-sdk'].version
+      aws_version = "aws-sdk-v#{aws_version}"
+      details = { release: aws_version }
       plat = connection.direct_platform('aws', details)
       plat.name.must_equal 'aws'
-      plat.release.must_equal '2.0'
-      plat[:release].must_equal '2.0'
+      plat.release.must_equal aws_version
+      plat[:release].must_equal aws_version
     end
 
     it 'provides family hierarchy' do


### PR DESCRIPTION
This PR makes the release call functional for api platforms. This is needed for the upstream inspec detect which expects a release field.

Signed-off-by: Jared Quick <jquick@chef.io>