### PR TITLE
Create a master OS family and refactor specifications

### DIFF
--- a/test/unit/plugins/connection_test.rb
+++ b/test/unit/plugins/connection_test.rb
@@ -50,7 +50,7 @@ describe 'v1 Connection Plugin' do
       plat.cloud?.must_equal false
       plat.unix?.must_equal true
       plat.family.must_equal 'darwin'
-      plat.family_hierarchy.must_equal ['darwin', 'bsd', 'unix']
+      plat.family_hierarchy.must_equal ['darwin', 'bsd', 'unix', 'os']
     end
 
     it 'provides api direct platform' do
@@ -75,7 +75,7 @@ describe 'v1 Connection Plugin' do
     it 'provides family hierarchy' do
       plat = Train::Platforms.name('linux')
       family = connection.family_hierarchy(plat)
-      family.flatten.must_equal ['linux', 'unix']
+      family.flatten.must_equal ['linux', 'unix', 'os']
     end
 
     it 'must use the user-provided logger' do


### PR DESCRIPTION
This change creates a master OS family for the os detects. Along with this change is some small specifications refactor to improve load times.

Fixes https://github.com/chef/train/issues/260

Signed-off-by: Jared Quick <jquick@chef.io>