### PR TITLE
Add transport for Cisco IOS

### DIFF
--- a/lib/train/transports/cisco_ios.rb
+++ b/lib/train/transports/cisco_ios.rb
@@ -19,8 +19,7 @@ module Train::Transports
     option :enable_password
 
     def connection
-      validate_options(@options)
-      @connection ||= Connection.new(@options)
+      @connection ||= Connection.new(validate_options(@options).options)
     end
 
     class Connection < BaseConnection

--- a/lib/train/transports/cisco_ios.rb
+++ b/lib/train/transports/cisco_ios.rb
@@ -1,0 +1,135 @@
+# encoding: utf-8
+
+require 'train/plugins'
+require 'train/transports/ssh'
+
+module Train::Transports
+  class BadEnablePassword < Train::TransportError; end
+
+  class CiscoIOS < SSH
+    name 'cisco_ios'
+
+    option :host, required: true
+    option :user, required: true
+    option :port, default: 22, required: true
+
+    option :password, required: true
+
+    # Used to elevate to enable mode (similar to `sudo su` in Linux)
+    option :enable_password
+
+    def connection
+      validate_options(@options)
+      @connection ||= Connection.new(@options)
+    end
+
+    def validate_options(options)
+      super(options)
+    end
+
+    class Connection < BaseConnection
+      def initialize(options)
+        super(options)
+
+        @host = @options.delete(:host)
+        @user = @options.delete(:user)
+        @port = @options.delete(:port)
+
+        @enable_password = @options.delete(:enable_password)
+
+        @prompt = /^\S+[>#]\r\n.*$/
+      end
+
+      def uri
+        "ssh://#{@user}@#{@host}:#{@port}"
+      end
+
+      private
+
+      def establish_connection
+        logger.debug("[SSH] opening connection to #{self}")
+
+        @ssh = Net::SSH.start(
+          @host,
+          @user,
+          @options.delete_if { |_key, value| value.nil? },
+        )
+
+        @channel ||= open_channel
+
+        # Escalate privilege to enable mode if password is given
+        if @enable_password
+          run_command_via_channel("enable\r\n#{@enable_password}")
+        end
+
+        # Prevent `--MORE--` by removing terminal length limit
+        run_command_via_channel('terminal length 0')
+
+        @ssh
+      end
+
+      def run_command_via_connection(cmd)
+        @session ||= establish_connection
+
+        result = run_command_via_channel(cmd)
+        CommandResult.new(*format_result(result))
+      end
+
+      def format_result(result)
+        # IOS commands do not have an exit code, so we must capture known errors
+        case result
+        when /Invalid input detected/
+          ['', result, 1]
+        when /Bad IP address or host name/
+          ['', result, 1]
+        else
+          [result, '', 0]
+        end
+      end
+
+      def run_command_via_channel(cmd)
+        # Ensure buffer is empty before sending data
+        @buf = ''
+
+        logger.debug("[SSH] Running `#{cmd}` on #{self}")
+        @channel.send_data(cmd + "\r\n")
+
+        logger.debug('[SSH] waiting for prompt')
+        until @buf =~ @prompt
+          raise BadEnablePassword if @buf =~ /Bad secrets/
+          @channel.connection.process(0)
+        end
+
+        # Save the buffer and clear it for the next command
+        output = @buf.dup
+        @buf = ''
+
+        # Remove leading prompt
+        output.sub!(/(\r\n|^)\S+[>#]/, '')
+
+        # Remove command string
+        output.sub!(/#{cmd}\r\n/, '')
+
+        # Remove trailing prompt
+        output.gsub!(/\S+[>#](\r\n|$)/, '')
+
+        output
+      end
+
+      # Create an SSH channel that writes to @buf when data is received
+      def open_channel
+        logger.debug("[SSH] opening SSH channel to #{self}")
+        @ssh.open_channel do |ch|
+          ch.on_data do |_, data|
+            @buf += data
+          end
+
+          ch.send_channel_request('shell') do |_, success|
+            raise 'Failed to open SSH shell' unless success
+            logger.debug('[SSH] shell opened')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/train/transports/cisco_ios.rb
+++ b/lib/train/transports/cisco_ios.rb
@@ -26,9 +26,6 @@ module Train::Transports
       def initialize(options)
         super(options)
 
-        @session = nil
-        @buf = nil
-
         # Delete options to avoid passing them in to `Net::SSH.start` later
         @host = @options.delete(:host)
         @user = @options.delete(:user)

--- a/test/unit/transports/cisco_ios.rb
+++ b/test/unit/transports/cisco_ios.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+require 'helper'
+require 'train/transports/cisco_ios'
+
+describe 'Train::Transports::CiscoIOS' do
+  let(:cls) do
+    plat = Train::Platforms.name('mock').in_family('cisco_ios')
+    plat.add_platform_methods
+    Train::Platforms::Detect.stubs(:scan).returns(plat)
+    Train::Transports::CiscoIOS
+  end
+
+  let(:options) do
+    {
+      host: 'fakehost',
+      user: 'fakeuser',
+      password: 'fakepassword',
+    }
+  end
+
+  let(:cisco_ios) do
+    cls.new(options)
+  end
+
+  describe 'CiscoIOS::Connection' do
+    let(:connection) { cls.new(options).connection }
+
+    it 'raises an error when user is missing' do
+      options.delete(:user)
+      err = proc { cls.new(options).connection }.must_raise(Train::ClientError)
+      err.message.must_match(/must provide.*user/)
+    end
+
+    it 'raises an error when host is missing' do
+      options.delete(:host)
+      err = proc { cls.new(options).connection }.must_raise(Train::ClientError)
+      err.message.must_match(/must provide.*host/)
+    end
+
+    it 'raises an error when password is missing' do
+      options.delete(:password)
+      err = proc { cls.new(options).connection }.must_raise(Train::ClientError)
+      err.message.must_match(/must provide.*password/)
+    end
+
+    it 'provides a uri' do
+      connection.uri.must_equal 'ssh://fakeuser@fakehost:22'
+    end
+  end
+end

--- a/test/unit/transports/cisco_ios.rb
+++ b/test/unit/transports/cisco_ios.rb
@@ -11,7 +11,7 @@ describe 'Train::Transports::CiscoIOS' do
     Train::Transports::CiscoIOS
   end
 
-  let(:options) do
+  let(:opts) do
     {
       host: 'fakehost',
       user: 'fakeuser',
@@ -20,32 +20,73 @@ describe 'Train::Transports::CiscoIOS' do
   end
 
   let(:cisco_ios) do
-    cls.new(options)
+    cls.new(opts)
   end
 
   describe 'CiscoIOS::Connection' do
-    let(:connection) { cls.new(options).connection }
+    let(:connection) { cls.new(opts).connection }
 
-    it 'raises an error when user is missing' do
-      options.delete(:user)
-      err = proc { cls.new(options).connection }.must_raise(Train::ClientError)
-      err.message.must_match(/must provide.*user/)
+    describe '#initialize' do
+      it 'raises an error when user is missing' do
+        opts.delete(:user)
+        err = proc { cls.new(opts).connection }.must_raise(Train::ClientError)
+        err.message.must_match(/must provide.*user/)
+      end
+
+      it 'raises an error when host is missing' do
+        opts.delete(:host)
+        err = proc { cls.new(opts).connection }.must_raise(Train::ClientError)
+        err.message.must_match(/must provide.*host/)
+      end
+
+      it 'raises an error when password is missing' do
+        opts.delete(:password)
+        err = proc { cls.new(opts).connection }.must_raise(Train::ClientError)
+        err.message.must_match(/must provide.*password/)
+      end
+
+      it 'provides a uri' do
+        connection.uri.must_equal 'ssh://fakeuser@fakehost:22'
+      end
     end
 
-    it 'raises an error when host is missing' do
-      options.delete(:host)
-      err = proc { cls.new(options).connection }.must_raise(Train::ClientError)
-      err.message.must_match(/must provide.*host/)
+    describe '#format_result' do
+      it 'returns correctly when result is `good`' do
+        connection.send(:format_result, 'good').must_equal ['good', '', 0]
+      end
+
+      it 'returns correctly when result matches /Bad IP address/' do
+        output = "Translating \"nope\"\r\n\r\nTranslating \"nope\"\r\n\r\n% Bad IP address or host name\r\n% Unknown command or computer name, or unable to find computer address\r\n"
+        result = connection.send(:format_result, output)
+        result.must_equal ['', output, 1]
+      end
+
+      it 'returns correctly when result matches /Incomplete command/' do
+        output = "% Incomplete command.\r\n\r\n"
+        result = connection.send(:format_result, output)
+        result.must_equal ['', output, 1]
+      end
+
+      it 'returns correctly when result matches /Invalid input detected/' do
+        output = "             ^\r\n% Invalid input detected at '^' marker.\r\n\r\n"
+        result = connection.send(:format_result, output)
+        result.must_equal ['', output, 1]
+      end
+
+      it 'returns correctly when result matches /Unrecognized host/' do
+        output = "Translating \"nope\"\r\n% Unrecognized host or address, or protocol not running.\r\n\r\n"
+        result = connection.send(:format_result, output)
+        result.must_equal ['', output, 1]
+      end
     end
 
-    it 'raises an error when password is missing' do
-      options.delete(:password)
-      err = proc { cls.new(options).connection }.must_raise(Train::ClientError)
-      err.message.must_match(/must provide.*password/)
-    end
-
-    it 'provides a uri' do
-      connection.uri.must_equal 'ssh://fakeuser@fakehost:22'
+    describe '#format_output' do
+      it 'returns output containing only the output of the command executed' do
+        cmd = 'show calendar'
+        output = "show calendar\r\n10:35:50 UTC Fri Mar 23 2018\r\n7200_ios_12#\r\n7200_ios_12#"
+        result = connection.send(:format_output, output, cmd)
+        result.must_equal '10:35:50 UTC Fri Mar 23 2018'
+      end
     end
   end
 end

--- a/test/unit/transports/cisco_ios.rb
+++ b/test/unit/transports/cisco_ios.rb
@@ -52,31 +52,33 @@ describe 'Train::Transports::CiscoIOS' do
 
     describe '#format_result' do
       it 'returns correctly when result is `good`' do
-        connection.send(:format_result, 'good').must_equal ['good', '', 0]
+        output = 'good'
+        Train::Extras::CommandResult.expects(:new).with(output, '', 0)
+        connection.send(:format_result, 'good')
       end
 
       it 'returns correctly when result matches /Bad IP address/' do
         output = "Translating \"nope\"\r\n\r\nTranslating \"nope\"\r\n\r\n% Bad IP address or host name\r\n% Unknown command or computer name, or unable to find computer address\r\n"
-        result = connection.send(:format_result, output)
-        result.must_equal ['', output, 1]
+        Train::Extras::CommandResult.expects(:new).with('', output, 1)
+        connection.send(:format_result, output)
       end
 
       it 'returns correctly when result matches /Incomplete command/' do
         output = "% Incomplete command.\r\n\r\n"
-        result = connection.send(:format_result, output)
-        result.must_equal ['', output, 1]
+        Train::Extras::CommandResult.expects(:new).with('', output, 1)
+        connection.send(:format_result, output)
       end
 
       it 'returns correctly when result matches /Invalid input detected/' do
         output = "             ^\r\n% Invalid input detected at '^' marker.\r\n\r\n"
-        result = connection.send(:format_result, output)
-        result.must_equal ['', output, 1]
+        Train::Extras::CommandResult.expects(:new).with('', output, 1)
+        connection.send(:format_result, output)
       end
 
       it 'returns correctly when result matches /Unrecognized host/' do
         output = "Translating \"nope\"\r\n% Unrecognized host or address, or protocol not running.\r\n\r\n"
-        result = connection.send(:format_result, output)
-        result.must_equal ['', output, 1]
+        Train::Extras::CommandResult.expects(:new).with('', output, 1)
+        connection.send(:format_result, output)
       end
     end
 


### PR DESCRIPTION
This adds transport support for Cisco IOS devices.

Given that the IOS SSH server closes the SSH channel after the first read (see: https://github.com/net-ssh/net-ssh/issues/24), it is required that we ensure the SSH channel stays open.

This is done here by creating a channel, creating a buffer to receive data/manipulate that data on that channel, and requesting a shell. This, coupled with the handling of the lack of exit codes and providing a method for escalating to enable mode, should allow support for Cisco IOS devices.
