### PR TITLE
Add MSI connection option for azure.

### DIFF
--- a/lib/train/transports/azure.rb
+++ b/lib/train/transports/azure.rb
@@ -4,6 +4,8 @@ require 'train/plugins'
 require 'ms_rest_azure'
 require 'azure_mgmt_resources'
 require 'inifile'
+require 'socket'
+require 'timeout'
 
 module Train::Transports
   class Azure < Train.plugin(1)
@@ -12,6 +14,7 @@ module Train::Transports
     option :client_id, default: ENV['AZURE_CLIENT_ID']
     option :client_secret, default: ENV['AZURE_CLIENT_SECRET']
     option :subscription_id, default: ENV['AZURE_SUBSCRIPTION_ID']
+    option :msi_port, default: ENV['AZURE_MSI_PORT'] || '50342'
 
     # This can provide the client id and secret
     option :credentials_file, default: ENV['AZURE_CRED_FILE']
@@ -36,6 +39,8 @@ module Train::Transports
           parse_credentials_file
         end
 
+        @options[:msi_port] = @options[:msi_port].to_i unless @options[:msi_port].nil?
+
         # additional platform details
         release = Gem.loaded_specs['azure_mgmt_resources'].version
         @platform_details = { release: "azure_mgmt_resources-v#{release}" }
@@ -54,19 +59,24 @@ module Train::Transports
       end
 
       def connect
-        provider = ::MsRestAzure::ApplicationTokenProvider.new(
-          @options[:tenant_id],
-          @options[:client_id],
-          @options[:client_secret],
-        )
+        if @options[:client_id].nil? && @options[:client_secret].nil? && port_open?(@options[:msi_port])
+          # try using MSI connection
+          provider = ::MsRestAzure::MSITokenProvider.new(@options[:msi_port])
+        else
+          provider = ::MsRestAzure::ApplicationTokenProvider.new(
+            @options[:tenant_id],
+            @options[:client_id],
+            @options[:client_secret],
+          )
+        end
 
         @credentials = {
           credentials: ::MsRest::TokenCredentials.new(provider),
           subscription_id: @options[:subscription_id],
           tenant_id: @options[:tenant_id],
-          client_id: @options[:client_id],
-          client_secret: @options[:client_secret],
         }
+        @credentials[:client_id] = @options[:client_id] unless @options[:client_id].nil?
+        @credentials[:client_secret] = @options[:client_secret] unless @options[:client_secret].nil?
       end
 
       def uri
@@ -119,6 +129,19 @@ module Train::Transports
       end
 
       private
+
+      def port_open?(port, seconds = 1)
+        Timeout.timeout(seconds) do
+          begin
+            TCPSocket.new('localhost', port).close
+            true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            false
+          end
+        end
+      rescue Timeout::Error
+        false
+      end
 
       def parse_credentials_file # rubocop:disable Metrics/AbcSize
         # If an AZURE_CRED_FILE environment variable has been specified set the

--- a/test/unit/transports/azure_test.rb
+++ b/test/unit/transports/azure_test.rb
@@ -83,11 +83,31 @@ describe 'azure transport' do
   describe 'connect' do
     it 'validate credentials' do
       connection.connect
+      token = credentials[:credentials].instance_variable_get(:@token_provider)
+      token.class.must_equal MsRestAzure::ApplicationTokenProvider
+
       credentials[:credentials].class.must_equal MsRest::TokenCredentials
       credentials[:tenant_id].must_equal 'test_tenant_id'
       credentials[:client_id].must_equal 'test_client_id'
       credentials[:client_secret].must_equal 'test_client_secret'
       credentials[:subscription_id].must_equal 'test_subscription_id'
+    end
+
+    it 'validate msi credentials' do
+      options[:client_id] = nil
+      options[:client_secret] = nil
+      Train::Transports::Azure::Connection.any_instance.stubs(:port_open?).returns(true)
+
+      connection.connect
+      token = credentials[:credentials].instance_variable_get(:@token_provider)
+      token.class.must_equal MsRestAzure::MSITokenProvider
+
+      credentials[:credentials].class.must_equal MsRest::TokenCredentials
+      credentials[:tenant_id].must_equal 'test_tenant_id'
+      credentials[:subscription_id].must_equal 'test_subscription_id'
+      credentials[:client_id].must_be_nil
+      credentials[:client_secret].must_be_nil
+      options[:msi_port].must_equal 50342
     end
   end
 


### PR DESCRIPTION
This adds the MSI connection option for azure. This only activates if client id/secret are not provided and if the MSI port is active.

Running on a MSI enabled node:
![screen shot 2018-03-23 at 10 35 30 am](https://user-images.githubusercontent.com/574637/37835849-7ec14d50-2e87-11e8-9d70-bbde7caf7c58.png)

Running on a azure shell which has MSI
![screen shot 2018-03-23 at 10 35 00 am](https://user-images.githubusercontent.com/574637/37835852-80110790-2e87-11e8-9899-440088e8a7a2.png)

`az` is not required and only the MSI framework.
 

Signed-off-by: Jared Quick <jquick@chef.io>