### PR TITLE
Update errors to have a base type of Train::Error

### DIFF
--- a/lib/train/errors.rb
+++ b/lib/train/errors.rb
@@ -9,21 +9,24 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 
 module Train
+  # Base exception for any exception explicitly raised by the Train library.
+  class Error < ::StandardError; end
+
   # Base exception class for all exceptions that are caused by user input
   # errors.
-  class UserError < ::StandardError; end
+  class UserError < Error; end
 
   # Base exception class for all exceptions that are caused by incorrect use
   # of an API.
-  class ClientError < ::StandardError; end
+  class ClientError < Error; end
 
   # Base exception class for all exceptions that are caused by other failures
   # in the transport layer.
-  class TransportError < ::StandardError; end
+  class TransportError < Error; end
 
   # Exception for when no platform can be detected.
-  class PlatformDetectionFailed < ::StandardError; end
+  class PlatformDetectionFailed < Error; end
 
   # Exception for when a invalid cache type is passed.
-  class UnknownCacheType < ::StandardError; end
+  class UnknownCacheType < Error; end
 end

--- a/lib/train/transports/local.rb
+++ b/lib/train/transports/local.rb
@@ -4,13 +4,14 @@
 # author: Christoph Hartmann
 
 require 'train/plugins'
+require 'train/errors'
 require 'mixlib/shellout'
 
 module Train::Transports
   class Local < Train.plugin(1)
     name 'local'
 
-    class PipeError < ::StandardError; end
+    class PipeError < Train::TransportError; end
 
     def connection(_ = nil)
       @connection ||= Connection.new(@options)


### PR DESCRIPTION
Train::Error inherits from StandardError.

This simplifies integrating this library, allowing the caller to
implement common Train error handling without having to be updated
when new error types are added to the gem.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>