### PR TITLE
Modify IOS connection options and add handling for commands with pipes

### DIFF
--- a/lib/train/transports/cisco_ios.rb
+++ b/lib/train/transports/cisco_ios.rb
@@ -121,7 +121,7 @@ module Train::Transports
       # we need to format the data to match what we would expect from Train
       def format_output(output, cmd)
         leading_prompt = /(\r\n|^)\S+[>#]/
-        command_string = /#{cmd}\r\n/
+        command_string = /#{Regexp.quote(cmd)}\r\n/
         trailing_prompt = /\S+[>#](\r\n|$)/
         trailing_line_endings = /(\r\n)+$/
 

--- a/test/unit/transports/cisco_ios.rb
+++ b/test/unit/transports/cisco_ios.rb
@@ -83,11 +83,18 @@ describe 'Train::Transports::CiscoIOS' do
     end
 
     describe '#format_output' do
-      it 'returns output containing only the output of the command executed' do
+      it 'returns the correct output' do
         cmd = 'show calendar'
         output = "show calendar\r\n10:35:50 UTC Fri Mar 23 2018\r\n7200_ios_12#\r\n7200_ios_12#"
         result = connection.send(:format_output, output, cmd)
         result.must_equal '10:35:50 UTC Fri Mar 23 2018'
+      end
+
+      it 'returns the correct output when a pipe is used' do
+        cmd = 'show running-config | section line con 0'
+        output = "show running-config | section line con 0\r\nline con 0\r\n exec-timeout 0 0\r\n privilege level 15\r\n logging synchronous\r\n stopbits 1\r\n7200_ios_12#\r\n7200_ios_12#"
+        result = connection.send(:format_output, output, cmd)
+        result.must_equal "line con 0\r\n exec-timeout 0 0\r\n privilege level 15\r\n logging synchronous\r\n stopbits 1"
       end
     end
   end


### PR DESCRIPTION
This does the following:
  - Modifies the connection options passed to `Net::SSH.start` to match the other SSH implementation
  - Adds handling for commands containing `|`