### PR TITLE
Add CloudLinux as a detected platform

### DIFF
--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -201,7 +201,7 @@ module Train::Platforms::Detect::Specifications
             if lsb && lsb[:id] =~ /cloudlinux/i
               @platform[:release] = lsb[:release]
               true
-            elsif (raw = unix_file_contents('/etc/system-release')) =~ /cloudlinux/i
+            elsif (raw = unix_file_contents('/etc/redhat-release')) =~ /cloudlinux/i
               @platform[:name] = redhatish_platform(raw)
               @platform[:release] = redhatish_version(raw)
               true

--- a/lib/train/platforms/detect/specifications/os.rb
+++ b/lib/train/platforms/detect/specifications/os.rb
@@ -195,6 +195,18 @@ module Train::Platforms::Detect::Specifications
               true
             end
           }
+      plat.name('cloudlinux').title('CloudLinux').in_family('redhat')
+          .detect {
+            lsb = read_linux_lsb
+            if lsb && lsb[:id] =~ /cloudlinux/i
+              @platform[:release] = lsb[:release]
+              true
+            elsif (raw = unix_file_contents('/etc/system-release')) =~ /cloudlinux/i
+              @platform[:name] = redhatish_platform(raw)
+              @platform[:release] = redhatish_version(raw)
+              true
+            end
+          }
       # keep redhat at the end as a fallback for anything with a redhat-release
       plat.name('redhat').title('Red Hat Linux').in_family('redhat')
           .detect {

--- a/test/unit/platforms/os_detect_test.rb
+++ b/test/unit/platforms/os_detect_test.rb
@@ -54,6 +54,16 @@ describe 'os_detect' do
         platform[:family].must_equal('redhat')
         platform[:release].must_equal('7.4')
       end
+      it 'sets the correct family, name, and release on CloudLinux' do
+        files = {
+          '/etc/redhat-release' => "CloudLinux release 7.4 (Georgy Grechko)\n",
+          '/etc/os-release' => "NAME=\"CloudLinux\"\nVERSION=\"7.4 (Georgy Grechko)\"\nID=\"cloudlinux\"\nID_LIKE=\"rhel fedora centos\"\nVERSION_ID=\"7.4\"\nPRETTY_NAME=\"CloudLinux 7.4 (Georgy Grechko)\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:cloudlinux:cloudlinux:7.4:GA:server\"\nHOME_URL=\"https://www.cloudlinux.com//\"\nBUG_REPORT_URL=\"https://www.cloudlinux.com/support\"\n",
+        }
+        platform = scan_with_files('linux', files)
+        platform[:name].must_equal('cloudlinux')
+        platform[:family].must_equal('redhat')
+        platform[:release].must_equal('7.4')
+      end
     end
   end
 

--- a/test/unit/platforms/platform_test.rb
+++ b/test/unit/platforms/platform_test.rb
@@ -133,6 +133,15 @@ describe 'platform' do
     it { os.unix?.must_equal(true) }
   end
 
+  describe 'with platform set to cloudlinux' do
+    let(:os) { mock_platform('cloudlinux') }
+    it { os.redhat?.must_equal(true) }
+    it { os.debian?.must_equal(false) }
+    it { os.suse?.must_equal(false) }
+    it { os.linux?.must_equal(true) }
+    it { os.unix?.must_equal(true) }
+  end
+
   describe 'with platform set to fedora' do
     let(:os) { mock_platform('fedora') }
     it { os.fedora?.must_equal(true) }


### PR DESCRIPTION
This update adds support for detecting CloudLinux as an OS.