### PR TITLE
Add handling for privileged exec mode

### DIFF
--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -38,7 +38,11 @@ class Train::Transports::SSH
 
       # Escalate privilege to enable mode if password is given
       if @enable_password
-        run_command_via_connection("enable\r\n#{@enable_password}")
+        # This verifies we are not in privileged exec mode before running the
+        # enable command. Otherwise, the password will be in history.
+        if run_command_via_connection('show privilege').stdout.split[-1] != '15'
+          run_command_via_connection("enable\r\n#{@enable_password}")
+        end
       end
 
       # Prevent `--MORE--` by removing terminal length limit


### PR DESCRIPTION
This ensures that passwords are not written into history by not running the `enable` command when already in privileged exec mode.
