### PR TITLE
switched method of determining aws account id to STS

### DIFF
--- a/lib/train/transports/aws.rb
+++ b/lib/train/transports/aws.rb
@@ -62,9 +62,8 @@ module Train::Transports
 
       def unique_identifier
         # use aws account id
-        client = aws_client(::Aws::IAM::Client)
-        arn = client.get_user.user.arn
-        arn.split(':')[4]
+        client = aws_client(::Aws::STS::Client)
+        client.get_caller_identity.account
       end
     end
   end

--- a/test/unit/transports/aws_test.rb
+++ b/test/unit/transports/aws_test.rb
@@ -98,26 +98,23 @@ describe 'aws transport' do
   end
 
   describe 'unique_identifier' do
-    class AwsArn
-      def arn
-        'arn:aws:iam::158551926027:user/test-fixture-maker'
+
+    class AwsCallerId
+      def account
+        "123456789012"
       end
     end
 
-    class AwsUser
-      def user
-        AwsArn.new
+    class StsClient
+      def get_caller_identity
+        AwsCallerId.new
       end
     end
 
-    class AwsClient
-      def get_user
-        AwsUser.new
-      end
-    end
     it 'returns an account id' do
-      connection.stubs(:aws_client).returns(AwsClient.new)
-      connection.unique_identifier.must_equal '158551926027'
+      connection.stubs(:aws_client).returns(StsClient.new)
+      connection.unique_identifier.must_equal '123456789012'
     end
   end
+
 end


### PR DESCRIPTION
## Description
Encountered error "Must specify userName when calling with non-User credentials" when using temporary AWS credentials through inspec aws.

## Train and Platform Version
Inspec version 2.1.26 worked fine, 2.1.27 stopped working. Discovered that I was using train version 1.4.0. Tested this with the newest git clone from today. I'm not sure when/how inspec switched the dependency, but that shouldn't affect this issue.

## Replication Case
run ` bundle exec inspec exec --log-level=debug -t aws://` when using AWS temporary credentials.

## Possible Solutions
Found references of this problem in other repos, along with indication that going through STS instead of IAM is more stable. Changed the aws transport to do so, and now the inspec command runs without complaints.

## Stacktrace
```
> bundle exec inspec exec --log-level=debug -t aws:// --reporter cli
[2018-04-19T17:05:39+02:00] DEBUG: Option backend_cache is enabled
[2018-04-19T17:05:39+02:00] DEBUG: Starting run with targets: []
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/aws-sdk-core-2.11.33/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/aws-sdk-core-2.11.33/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/aws-sdk-core-2.11.33/lib/aws-sdk-core/plugins/idempotency_token.rb:18:in `call'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/aws-sdk-core-2.11.33/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/aws-sdk-core-2.11.33/lib/seahorse/client/plugins/response_target.rb:21:in `call'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/aws-sdk-core-2.11.33/lib/seahorse/client/request.rb:70:in `send_request'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/aws-sdk-core-2.11.33/lib/seahorse/client/base.rb:207:in `block (2 levels) in define_operation_methods'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/train-1.4.0/lib/train/transports/aws.rb:66:in `unique_identifier'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/train-1.4.0/lib/train/platforms/detect/uuid.rb:19:in `find_or_create_uuid'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/train-1.4.0/lib/train/platforms/platform.rb:45:in `uuid'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/train-1.4.0/lib/train/platforms/platform.rb:52:in `[]'
/private/tmp/inspec/lib/resources/platform.rb:41:in `[]'
/private/tmp/inspec/lib/inspec/formatters/base.rb:194:in `platform'
/private/tmp/inspec/lib/inspec/formatters/base.rb:69:in `stop'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:206:in `block in notify'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:205:in `each'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:205:in `notify'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:199:in `stop'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:172:in `block in finish'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:191:in `close_after'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:171:in `finish'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/reporter.rb:81:in `report'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.7.1/lib/rspec/core/runner.rb:112:in `run_specs'
/private/tmp/inspec/lib/inspec/runner_rspec.rb:77:in `run'
/private/tmp/inspec/lib/inspec/runner.rb:132:in `run_tests'
/private/tmp/inspec/lib/inspec/runner.rb:104:in `run'
/private/tmp/inspec/lib/inspec/cli.rb:168:in `exec'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
/tmp/inspec/bin/inspec:12:in `<top (required)>'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/bin/inspec:23:in `load'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/bin/inspec:23:in `<top (required)>'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/gems/bundler-1.16.1/exe/bundle:22:in `<top (required)>'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `load'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/bin/bundle:23:in `<main>'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/Users/tkruger1/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
Must specify userName when calling with non-User credentials
```
