### PR TITLE
Provide additional gemspecs for various backends and a 'core' that they all depend on.

### DIFF
--- a/train-aws.gemspec
+++ b/train-aws.gemspec
@@ -1,0 +1,22 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'train/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'train-aws'
+  spec.version       = Train::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Provides AWS support to train-core.'
+  spec.description   = 'Provides AWS support to train-core.'
+  spec.homepage      = 'https://github.com/chef/train/'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w[train-aws.gemspec README.md LICENSE Gemfile CHANGELOG.md
+                  lib/train/transports/aws.rb]
+
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'train-core'
+  spec.add_dependency 'aws-sdk', '~> 2'
+end

--- a/train-azure.gemspec
+++ b/train-azure.gemspec
@@ -1,0 +1,22 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'train/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'train-azure'
+  spec.version       = Train::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Provides Azure support to train-core.'
+  spec.description   = 'Provides Azure support to train-core.'
+  spec.homepage      = 'https://github.com/chef/train/'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w[train-azure.gemspec README.md LICENSE CHANGELOG.md
+                  lib/train/transports/azure.rb]
+
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'train-core'
+  spec.add_dependency 'azure_mgmt_resources', '~> 0.15'
+end

--- a/train-core.gemspec
+++ b/train-core.gemspec
@@ -1,0 +1,34 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'train/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'train-core'
+  spec.version       = Train::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Transport interface to talk to a selected set of backends.'
+  spec.description   = 'A minimal Train with a selected set of backends, ssh, winrm, and docker.'
+  spec.homepage      = 'https://github.com/chef/train/'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w{train-core.gemspec README.md LICENSE Gemfile CHANGELOG.md} +
+    Dir.glob('{lib,test}/**/*', File::FNM_DOTMATCH)
+    .reject { |f| File.directory?(f) || f =~ /aws|azure|gcp/ }
+
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'json', '>= 1.8', '< 3.0'
+  # chef-client < 12.4.1 require mixlib-shellout-2.0.1
+  spec.add_dependency 'mixlib-shellout', '~> 2.0'
+  # net-ssh 3.x drops Ruby 1.9 support, so this constraint could be raised when
+  # 1.9 support is no longer needed here or for Inspec
+  spec.add_dependency 'net-ssh', '>= 2.9', '< 5.0'
+  spec.add_dependency 'net-scp', '~> 1.2'
+  spec.add_dependency 'winrm', '~> 2.0'
+  spec.add_dependency 'winrm-fs', '~> 1.0'
+  spec.add_dependency 'docker-api', '~> 1.26'
+  spec.add_dependency 'inifile'
+end

--- a/train-gcp.gemspec
+++ b/train-gcp.gemspec
@@ -1,0 +1,25 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'train/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'train-gcp'
+  spec.version       = Train::VERSION
+  spec.authors       = ['Dominik Richter']
+  spec.email         = ['dominik.richter@gmail.com']
+  spec.summary       = 'Provides Google Cloud Provider support to train-core.'
+  spec.description   = 'Provides Google Cloud Provider support to train-core.'
+  spec.homepage      = 'https://github.com/chef/train/'
+  spec.license       = 'Apache-2.0'
+
+  spec.files = %w[train-gcp.gemspec README.md LICENSE CHANGELOG.md
+                  lib/train/transports/gcp.rb]
+
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'train-core'
+  spec.add_dependency 'google-api-client', '~> 0.19.8'
+  spec.add_dependency 'googleauth', '~> 0.6.2'
+  spec.add_dependency 'google-cloud', '~> 0.51.1'
+  spec.add_dependency 'google-protobuf', '= 3.5.1'
+end


### PR DESCRIPTION
This adds a few gem specs to allow Train to be distributed without support for additional cloud providers. I've left the `train.gemspec` alone so train can still be distributed as is. In the future after these supplemental gem specs have proven themselves `train.gemspec` would be modified to depend on them.

We now have:

 - `train-core` which is just Train, with WinRM, SSH, and Docker support.
 - `train-aws` which provides AWS support.
 - `train-azure` which provides Azure support.
 - `train-gcp`  which provides Google Cloud Provider support.

The aws, azure, and gcp gems all depend on `core`.  So if you want to install Train with support for AWS you can install `train-aws` and you'll be fine.

The `description` and `summary` of our gem specs could probably be improved here (HELP)

These supplemental gem specs do not include distribution of `tests` (spec.test_files) as that was [deprecated](https://github.com/rubygems/guides/issues/90). 