### PR TITLE
Support encoded passwords in target url

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -66,8 +66,13 @@ module Train
       conf[:host]     ||= uri.hostname
       conf[:port]     ||= uri.port
       conf[:user]     ||= uri.user
-      conf[:password] ||= uri.password
       conf[:path]     ||= uri.path
+      conf[:password] ||=
+        if conf[:www_form_encoded_password]
+          URI.decode_www_form_component(uri.password)
+        else
+          uri.password
+        end
     end
 
     # ensure path is nil, if its empty; e.g. required to reset defaults for winrm

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -177,6 +177,20 @@ describe Train do
       res[:target].must_equal org[:target]
     end
 
+    it 'supports www-form encoded passwords when the option is set' do
+      raw_password = '+!@#$%^&*()_-\';:"\\|/?.>,<][}{=`~'
+      encoded_password = URI.encode_www_form_component(raw_password)
+      org = { target: "mock://username:#{encoded_password}@1.2.3.4:100",
+              www_form_encoded_password: true}
+      res = Train.target_config(org)
+      res[:backend].must_equal 'mock'
+      res[:host].must_equal '1.2.3.4'
+      res[:user].must_equal 'username'
+      res[:password].must_equal raw_password
+      res[:port].must_equal 100
+      res[:target].must_equal org[:target]
+    end
+
     it 'it raises UserError on invalid URIs' do
       org = { target: 'mock world' }
       proc { Train.target_config(org) }.must_raise Train::UserError


### PR DESCRIPTION
In order to accept special characters in passwords that are
embedded in a URL (such as `ssh://user:!@#$$%(*@host` encoded as
`ssh://user:%5E%21%4023237%25%28*%40@host`), this change adds
a new option www_form_encoded_password.

When the option is present, `target_config` 'password' field
will contain the decoded value.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>