### PR TITLE
Allow nil password and www_form_encoded_password to work together.

### DIFF
--- a/lib/train.rb
+++ b/lib/train.rb
@@ -68,7 +68,7 @@ module Train
       conf[:user]     ||= uri.user
       conf[:path]     ||= uri.path
       conf[:password] ||=
-        if conf[:www_form_encoded_password]
+        if conf[:www_form_encoded_password] && !uri.password.nil?
           URI.decode_www_form_component(uri.password)
         else
           uri.password

--- a/test/unit/train_test.rb
+++ b/test/unit/train_test.rb
@@ -191,6 +191,18 @@ describe Train do
       res[:target].must_equal org[:target]
     end
 
+    it 'ignores www-form-encoded password value when there is no password' do
+      org = { target: "mock://username@1.2.3.4:100",
+              www_form_encoded_password: true}
+      res = Train.target_config(org)
+      res[:backend].must_equal 'mock'
+      res[:host].must_equal '1.2.3.4'
+      res[:user].must_equal 'username'
+      res[:password].must_be_nil
+      res[:port].must_equal 100
+      res[:target].must_equal org[:target]
+    end
+
     it 'it raises UserError on invalid URIs' do
       org = { target: 'mock world' }
       proc { Train.target_config(org) }.must_raise Train::UserError


### PR DESCRIPTION
This corrects a bug previously untested path in the change to support www-form-encoded password . 

When a URL does not contain a password but options contains
www_form_encoded_password: true, an exception was raised
because we can't decode a nil value.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>