### PR TITLE
Change Cisco IOS transport log level to INFO

### DIFF
--- a/lib/train/transports/cisco_ios_connection.rb
+++ b/lib/train/transports/cisco_ios_connection.rb
@@ -7,6 +7,8 @@ class Train::Transports::SSH
     def initialize(options)
       super(options)
 
+      logger.level = Logger::INFO
+
       # Extract options to avoid passing them in to `Net::SSH.start` later
       @host = options.delete(:host)
       @user = options.delete(:user)


### PR DESCRIPTION
This suppresses debug messages from being shown by default.