### PR TITLE
support sudo passwords for cisco

### DIFF
--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -202,7 +202,10 @@ module Train::Transports
         ios_options = {}
         ios_options[:host] = @options[:host]
         ios_options[:user] = @options[:user]
-        ios_options[:enable_password] = @options[:enable_password]
+        # The enable password is used to elevate privileges on Cisco devices
+        # We will also support the sudo password field for the same purpose
+        # for the interim.
+        ios_options[:enable_password] = @options[:enable_password] || @options[:sudo_password]
         ios_options.merge!(@connection_options)
         conn = CiscoIOSConnection.new(ios_options)
       end

--- a/lib/train/transports/ssh.rb
+++ b/lib/train/transports/ssh.rb
@@ -204,7 +204,7 @@ module Train::Transports
         ios_options[:user] = @options[:user]
         # The enable password is used to elevate privileges on Cisco devices
         # We will also support the sudo password field for the same purpose
-        # for the interim.
+        # for the interim. # TODO
         ios_options[:enable_password] = @options[:enable_password] || @options[:sudo_password]
         ios_options.merge!(@connection_options)
         conn = CiscoIOSConnection.new(ios_options)


### PR DESCRIPTION
feed the sudo password into the enable password field on Cisco devices. If the user specifies this priviledge elevation, it can serve the same purpose as the enable password. This support is temporary until a few other pieces land.