### PR TITLE
Allow TrainError to provide a supplement reason

### DIFF
--- a/lib/train/errors.rb
+++ b/lib/train/errors.rb
@@ -10,7 +10,14 @@
 
 module Train
   # Base exception for any exception explicitly raised by the Train library.
-  class Error < ::StandardError; end
+  class Error < ::StandardError
+    attr_reader :reason
+
+    def initialize(message = '', reason = :not_provided)
+      super(message)
+      @reason = reason
+    end
+  end
 
   # Base exception class for all exceptions that are caused by user input
   # errors.


### PR DESCRIPTION
This modifies Train::Error to provide a 'reason' field,
allowing client applications to present error messaging
appropriate to their usage when the default train messages
are not a good fit.

Currently, only sudo-related errors in CommandWrapper are making use of
this.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>